### PR TITLE
feat(project): add project-based repository management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,42 +1,63 @@
-# Copilot Custom Instructions
+# Copilot Instructions for eng
 
-<!-- Use this file to provide workspace-specific custom instructions to Copilot. For more details, visit https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file -->
+These guidelines make AI agents productive in this Go CLI codebase by codifying architecture, workflows, and house conventions. Keep it concise and concrete.
 
-## General
+## Big Picture
 
-- Keep the README.md file up to date with the latest information about the project.
-- Use clear and concise language in comments and documentation.
+- CLI framework: Cobra entry at [cmd/root.go](cmd/root.go); `main()` delegates to `cmd.Execute()` in [main.go](main.go).
+- Module layout: Subcommands under [cmd/](cmd) mirror features (git, dotfiles, system, codemod, ts, version, config, gitlab).
+- Configuration: Viper-backed YAML at `$HOME/.eng.yaml` created/migrated on startup; see [utils/config/migration.go](utils/config/migration.go).
+- Logging: Local colorized logger in [utils/log/log.go](utils/log/log.go); use it for all output and for `io.Writer`s.
+- External tooling: Uses `glab`, `bw` (Bitwarden CLI), Homebrew, git-chglog, goreleaser where relevant (see [README.md](README.md)).
 
-## Go
+## Development Workflow
 
-- Always write idiomatic Go code.
-- Use the Go standard library whenever possible.
-- Use the `go` command to run tests, build, and install packages.
-- Use `golangci-lint` to format code.
-- Use `golangci-lint run` to check for linting issues.
-- Use `go test` to run tests.
-- Use `go mod` to manage dependencies.
+- Build: `task build` (outputs `./eng`) or `go build`; install with `task install` or `go install`.
+- Lint/format: `task lint` (golangci-lint). Use `task format` / `task format-check` before commits.
+- Test: `task test` runs `go test ./... -cover -race`.
+- Validate: `task validate` runs format + lint + test.
+- Releases/changelog: `task release`, `task changelog` (see [Taskfile.yaml](Taskfile.yaml)).
+- Version ldflags: Build injects `Version`, `Commit`, `Date` for [cmd/version/version.go](cmd/version/version.go) using Taskfile `GO_BUILD_FLAGS`.
 
-- Always write tests for new code.
-- Always update tests when modifying existing code.
-- Use `go test -cover` to check test coverage.
-- Use `go vet` to check for common mistakes.
-- Use `go doc` to generate documentation.
+## Conventions
 
-## git Commit messages
+- Logging: Prefer `log.Start/Success/Info/Debug/Warn/Error` and `log.Verbose(v, ...)` for noisy output.
+- Command output piping: For spawned processes, always wire `Stdout = log.Writer()` and `Stderr = log.ErrorWriter()`.
+- Verbose flag: Respect `--verbose` via `utils.IsVerbose(cmd)` or viper key `verbose`.
+- Errors: Return errors from helpers; let Cobra’s `CheckErr` or caller handle. Use `log.Fatal` only for unrecoverable process-level failures.
+- Modules: Keep feature code in `cmd/<feature>` and shared helpers in `utils/` or feature-scoped packages under `utils/`.
+- Tests: Use `testify` and prefer table-driven tests. When asserting logs, swap writers via `log.SetWriters` and `log.ResetWriters`.
 
-- Use conventional commit messages
-- Follow the commit message guidelines
-- See https://www.conventionalcommits.org/en/v1.0.0/
-- Start commit messages with a type (e.g., feat, fix, docs, style, refactor, test, chore)
-- Optionally include a scope in parentheses after the type (e.g., feat(parser): ...)
-- Use a short, imperative description after the type/scope
-- Separate the body from the header with a blank line if additional context is needed
-- Reference issues or pull requests in the footer if applicable
-- Mention breaking changes in the footer if present
+## Patterns & Examples
 
-## Project specific
+- Spawn a child process with proper signal/IO handling:
+  - Use `utils.StartChildProcess(exec.Command("tool", "args"...))` from [utils/command.go](utils/command.go).
+- Bitwarden integration:
+  - Use `utils.EnsureBitwardenSession()` and helpers in [utils/bitwarden.go](utils/bitwarden.go) to read/store secrets; do not parse `bw` JSON manually.
+- Config keys stability:
+  - Add migrations in [utils/config/migration.go](utils/config/migration.go) when renaming keys; call `viper.WriteConfig()` after changes.
+- Multi-repo git ops:
+  - Use commands in [cmd/git](cmd/git) that traverse the configured dev path (`eng config git-dev-path`), honoring `--current` and `--dry-run` where applicable.
 
-- Always use the local logging package.
-- Utilize the verbose logging as well for more detailed output.
-- Always use the log Writer and ErrorWriter when logging output of an exec.Command.
+## Integration Points
+
+- Dotfiles: Managed as a bare repo via go-git; top-level commands in [cmd/dotfiles](cmd/dotfiles). Config keys: `dotfiles-repo-url`, `dotfiles-branch`, `dotfiles-bare-repo-path`.
+- GitLab MR rules: See [cmd/gitlab](cmd/gitlab) for `mr-rules init/apply`; relies on `glab` and optional Bitwarden token retrieval.
+- Codemods: [cmd/codemod](cmd/codemod) includes `lint-setup`, `prettier`, and `copilot` templates under [cmd/codemod/\*.tmpl](cmd/codemod).
+- TypeScript helpers: Lightweight `ts up/down` commands in [cmd/ts](cmd/ts).
+
+## Commit Messages
+
+- Use Conventional Commits (feat, fix, chore, docs, refactor, test, style). Scope is encouraged, e.g., `feat(git): ...`.
+
+## Keep In Sync
+
+- Update [README.md](README.md) when adding commands, flags, or workflows.
+- Prefer adding `task` targets for repeatable workflows and reference them here and in the README.
+
+## Quick Checklist for New Code
+
+- Wire logs via `utils/log`; respect `--verbose`.
+- Add tests with `testify`; run `task validate`.
+- Update config migrations if any keys change.
+- Document new commands in [README.md](README.md) and add `task` targets if appropriate.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,9 +1,9 @@
-version: '3'
+version: "3"
 
 env:
   ENV: testing
 
-dotenv: ['.env', '{{.ENV}}/.env.', '{{.HOME}}/.env']
+dotenv: [".env", "{{.ENV}}/.env.", "{{.HOME}}/.env"]
 
 vars:
   # --- Versioning ---
@@ -36,7 +36,7 @@ tasks:
       - go install {{.GO_BUILD_FLAGS}} .
       - task: completion
     aliases:
-      - 'i'
+      - "i"
     deps: # Ensure build runs first if needed, though go install builds anyway
       - build
 

--- a/cmd/gitlab/auth/doctor.go
+++ b/cmd/gitlab/auth/doctor.go
@@ -155,7 +155,6 @@ var doctorCmd = &cobra.Command{
 func init() {
 	AuthCmd.AddCommand(doctorCmd)
 	doctorCmd.Flags().StringVar(&docHostOpt, "host", "", "GitLab host (e.g., gitlab.com)")
-	doctorCmd.Flags().StringVar(&docHostOpt, "hose", "", "Alias for --host")
 	doctorCmd.Flags().StringVar(&docProjectOpt, "project", "", "GitLab project path (e.g., group/subgroup/repo)")
 	doctorCmd.Flags().BoolVar(&docQuiet, "quiet", false, "Only print essential OK/error messages")
 }

--- a/cmd/gitlab/auth/doctor.go
+++ b/cmd/gitlab/auth/doctor.go
@@ -91,7 +91,10 @@ var doctorCmd = &cobra.Command{
 			cmdUser.Env = env
 			out, err := cmdUser.Output()
 			if err != nil {
-				return fmt.Errorf("failed to call glab api user (ensure GITLAB_TOKEN is set or configured via Bitwarden/config): %w", err)
+				return fmt.Errorf(
+					"failed to call glab api user (ensure GITLAB_TOKEN is set or configured via Bitwarden/config): %w",
+					err,
+				)
 			}
 			var user struct {
 				Username string `json:"username"`

--- a/cmd/gitlab/auth/doctor.go
+++ b/cmd/gitlab/auth/doctor.go
@@ -91,10 +91,7 @@ var doctorCmd = &cobra.Command{
 			cmdUser.Env = env
 			out, err := cmdUser.Output()
 			if err != nil {
-				return fmt.Errorf(
-					"failed to call glab api user: %w\nEnsure GITLAB_TOKEN is set or configured via Bitwarden/config",
-					err,
-				)
+				return fmt.Errorf("failed to call glab api user: %w\nEnsure GITLAB_TOKEN is set or configured via Bitwarden/config.", err)
 			}
 			var user struct {
 				Username string `json:"username"`
@@ -155,6 +152,7 @@ var doctorCmd = &cobra.Command{
 func init() {
 	AuthCmd.AddCommand(doctorCmd)
 	doctorCmd.Flags().StringVar(&docHostOpt, "host", "", "GitLab host (e.g., gitlab.com)")
+	doctorCmd.Flags().StringVar(&docHostOpt, "hose", "", "Alias for --host")
 	doctorCmd.Flags().StringVar(&docProjectOpt, "project", "", "GitLab project path (e.g., group/subgroup/repo)")
 	doctorCmd.Flags().BoolVar(&docQuiet, "quiet", false, "Only print essential OK/error messages")
 }

--- a/cmd/gitlab/auth/doctor.go
+++ b/cmd/gitlab/auth/doctor.go
@@ -91,7 +91,7 @@ var doctorCmd = &cobra.Command{
 			cmdUser.Env = env
 			out, err := cmdUser.Output()
 			if err != nil {
-				return fmt.Errorf("failed to call glab api user: %w\nEnsure GITLAB_TOKEN is set or configured via Bitwarden/config.", err)
+				return fmt.Errorf("failed to call glab api user (ensure GITLAB_TOKEN is set or configured via Bitwarden/config): %w", err)
 			}
 			var user struct {
 				Username string `json:"username"`

--- a/cmd/gitlab/auth/set.go
+++ b/cmd/gitlab/auth/set.go
@@ -50,7 +50,11 @@ var setCmd = &cobra.Command{
 			if strings.TrimSpace(setTokenItem) == "" {
 				return errors.New("--token-item is required when providing a token")
 			}
-			if _, err := utils.SaveOrUpdateBitwardenSecret(setTokenItem, strings.TrimSpace(tokenToSave), setNotes); err != nil {
+			if _, err := utils.SaveOrUpdateBitwardenSecret(
+				setTokenItem,
+				strings.TrimSpace(tokenToSave),
+				setNotes,
+			); err != nil {
 				return err
 			}
 			log.Success("Saved/updated GitLab token in Bitwarden item: %s", setTokenItem)
@@ -97,6 +101,7 @@ func init() {
 	setCmd.Flags().StringVar(&setToken, "token", "", "GitLab token to save into Bitwarden (discouraged; prefer stdin)")
 	setCmd.Flags().BoolVar(&setTokenStdin, "stdin", false, "Read token from STDIN")
 	setCmd.Flags().StringVar(&setHost, "host", "", "Default GitLab host to save in config (e.g., gitlab.com)")
-	setCmd.Flags().StringVar(&setProject, "project", "", "Default GitLab project path to save in config (e.g., group/sub/repo)")
+	setCmd.Flags().
+		StringVar(&setProject, "project", "", "Default GitLab project path to save in config (e.g., group/sub/repo)")
 	setCmd.Flags().StringVar(&setNotes, "notes", "", "Optional notes to save with the Bitwarden item")
 }

--- a/cmd/gitlab/auth/set.go
+++ b/cmd/gitlab/auth/set.go
@@ -50,11 +50,7 @@ var setCmd = &cobra.Command{
 			if strings.TrimSpace(setTokenItem) == "" {
 				return errors.New("--token-item is required when providing a token")
 			}
-			if _, err := utils.SaveOrUpdateBitwardenSecret(
-				setTokenItem,
-				strings.TrimSpace(tokenToSave),
-				setNotes,
-			); err != nil {
+			if _, err := utils.SaveOrUpdateBitwardenSecret(setTokenItem, strings.TrimSpace(tokenToSave), setNotes); err != nil {
 				return err
 			}
 			log.Success("Saved/updated GitLab token in Bitwarden item: %s", setTokenItem)
@@ -101,7 +97,6 @@ func init() {
 	setCmd.Flags().StringVar(&setToken, "token", "", "GitLab token to save into Bitwarden (discouraged; prefer stdin)")
 	setCmd.Flags().BoolVar(&setTokenStdin, "stdin", false, "Read token from STDIN")
 	setCmd.Flags().StringVar(&setHost, "host", "", "Default GitLab host to save in config (e.g., gitlab.com)")
-	setCmd.Flags().
-		StringVar(&setProject, "project", "", "Default GitLab project path to save in config (e.g., group/sub/repo)")
+	setCmd.Flags().StringVar(&setProject, "project", "", "Default GitLab project path to save in config (e.g., group/sub/repo)")
 	setCmd.Flags().StringVar(&setNotes, "notes", "", "Optional notes to save with the Bitwarden item")
 }

--- a/cmd/project/add.go
+++ b/cmd/project/add.go
@@ -150,6 +150,7 @@ Example:
 			Default: false,
 		}
 		if err := survey.AskOne(morePrompt, &addMore); err != nil {
+			log.Error("Prompt failed: %s", err)
 			return
 		}
 

--- a/cmd/project/add.go
+++ b/cmd/project/add.go
@@ -4,8 +4,8 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // AddCmd defines the cobra command for adding projects or repositories.

--- a/cmd/project/add.go
+++ b/cmd/project/add.go
@@ -1,0 +1,180 @@
+package project
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+)
+
+// AddCmd defines the cobra command for adding projects or repositories.
+// It provides interactive prompts for configuration.
+var AddCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a new project or repository to configuration",
+	Long: `This command interactively adds a new project or adds a repository to an existing project.
+
+You will be prompted for:
+  - Project name (new or existing)
+  - Repository URL (SSH or HTTPS)
+  - Optional custom directory name
+
+Example:
+  eng project add              # Interactive add
+  eng project add -p Echo      # Add a repo to the Echo project`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Start("Adding project configuration")
+
+		projectFilter, _ := cmd.Flags().GetString("project")
+
+		existingNames := config.GetProjectNames()
+
+		var projectName string
+
+		if projectFilter != "" {
+			// Use the specified project
+			projectName = projectFilter
+			found := false
+			for _, name := range existingNames {
+				if name == projectFilter {
+					found = true
+					break
+				}
+			}
+			if !found {
+				// Project doesn't exist, confirm creation
+				var confirmCreate bool
+				prompt := &survey.Confirm{
+					Message: "Project '" + projectFilter + "' doesn't exist. Create it?",
+					Default: true,
+				}
+				if err := survey.AskOne(prompt, &confirmCreate); err != nil {
+					log.Error("Prompt failed: %s", err)
+					return
+				}
+				if !confirmCreate {
+					log.Info("Canceled.")
+					return
+				}
+			}
+		} else {
+			// Interactive project selection/creation
+			options := append([]string{"[Create new project]"}, existingNames...)
+
+			var selection string
+			prompt := &survey.Select{
+				Message: "Select a project or create a new one:",
+				Options: options,
+			}
+			if err := survey.AskOne(prompt, &selection); err != nil {
+				log.Error("Prompt failed: %s", err)
+				return
+			}
+
+			if selection == "[Create new project]" {
+				namePrompt := &survey.Input{
+					Message: "Enter new project name:",
+				}
+				if err := survey.AskOne(namePrompt, &projectName, survey.WithValidator(survey.Required)); err != nil {
+					log.Error("Prompt failed: %s", err)
+					return
+				}
+			} else {
+				projectName = selection
+			}
+		}
+
+		// Get repository URL
+		var repoURL string
+		urlPrompt := &survey.Input{
+			Message: "Enter repository URL (SSH or HTTPS):",
+			Help:    "Examples: git@github.com:org/repo.git or https://github.com/org/repo.git",
+		}
+		if err := survey.AskOne(urlPrompt, &repoURL, survey.WithValidator(survey.Required)); err != nil {
+			log.Error("Prompt failed: %s", err)
+			return
+		}
+
+		// Derive default path from URL
+		defaultPath, err := config.RepoNameFromURL(repoURL)
+		if err != nil {
+			log.Error("Could not parse repository URL: %s", err)
+			return
+		}
+
+		// Ask for optional custom path
+		var customPath string
+		pathPrompt := &survey.Input{
+			Message: "Custom directory name (leave empty for default):",
+			Default: "",
+			Help:    "Default: " + defaultPath,
+		}
+		if err := survey.AskOne(pathPrompt, &customPath); err != nil {
+			log.Error("Prompt failed: %s", err)
+			return
+		}
+
+		// Create the repo entry
+		repo := config.ProjectRepo{
+			URL:  repoURL,
+			Path: customPath, // Empty string will use default
+		}
+
+		// Check if this is a new project
+		existingProject := config.GetProjectByName(projectName)
+		if existingProject == nil {
+			// Create new project
+			newProject := config.Project{
+				Name:  projectName,
+				Repos: []config.ProjectRepo{repo},
+			}
+			if err := config.AddProject(newProject); err != nil {
+				log.Error("Failed to add project: %s", err)
+				return
+			}
+			log.Success("Created new project '%s' with repository", projectName)
+		} else {
+			// Add to existing project
+			if err := config.AddRepoToProject(projectName, repo); err != nil {
+				log.Error("Failed to add repository: %s", err)
+				return
+			}
+			log.Success("Added repository to project '%s'", projectName)
+		}
+
+		// Ask if they want to add more
+		var addMore bool
+		morePrompt := &survey.Confirm{
+			Message: "Add another repository?",
+			Default: false,
+		}
+		if err := survey.AskOne(morePrompt, &addMore); err != nil {
+			return
+		}
+
+		if addMore {
+			// Re-run the add command for the same project
+			_ = cmd.Flags().Set("project", projectName)
+			cmd.Run(cmd, args)
+			return
+		}
+
+		log.Info("")
+		log.Info("Run 'eng project setup' to clone the new repositories.")
+
+		// Show current project state
+		updatedProjects := config.GetProjects()
+		for _, p := range updatedProjects {
+			if p.Name == projectName {
+				log.Info("")
+				log.Info("Project '%s' now has %d repository(ies):", p.Name, len(p.Repos))
+				for _, r := range p.Repos {
+					path, _ := r.GetEffectivePath()
+					log.Info("  - %s", path)
+				}
+				break
+			}
+		}
+	},
+}

--- a/cmd/project/add.go
+++ b/cmd/project/add.go
@@ -21,8 +21,8 @@ You will be prompted for:
   - Optional custom directory name
 
 Example:
-  eng project add              # Interactive add
-  eng project add -p Echo      # Add a repo to the Echo project`,
+  eng project add                  # Interactive add
+  eng project add -p MyProject     # Add a repo to the specified project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Start("Adding project configuration")
 

--- a/cmd/project/fetch.go
+++ b/cmd/project/fetch.go
@@ -8,9 +8,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/eng618/eng/utils"
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // FetchCmd defines the cobra command for fetching all project repositories.

--- a/cmd/project/fetch.go
+++ b/cmd/project/fetch.go
@@ -21,15 +21,15 @@ var FetchCmd = &cobra.Command{
 	Long: `This command fetches updates from remote for all repositories in configured projects.
 
 Example:
-  eng project fetch              # Fetch all projects
-  eng project fetch -p Echo      # Fetch only the Echo project
-  eng project fetch --dry-run    # Preview what would be fetched`,
+  eng project fetch                  # Fetch all projects
+  eng project fetch -p MyProject     # Fetch only the specified project
+  eng project fetch --dry-run        # Preview what would be fetched`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Start("Fetching project repositories")
 
 		isVerbose := utils.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		projectFilter, _ := cmd.Flags().GetString("project")
+		dryRun, _ := cmd.Parent().PersistentFlags().GetBool("dry-run")
+		projectFilter, _ := cmd.Parent().PersistentFlags().GetString("project")
 
 		devPath := viper.GetString("git.dev_path")
 		if devPath == "" {

--- a/cmd/project/fetch.go
+++ b/cmd/project/fetch.go
@@ -1,0 +1,121 @@
+package project
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/eng618/eng/utils"
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+)
+
+// FetchCmd defines the cobra command for fetching all project repositories.
+// It runs git fetch on all repositories in configured projects.
+var FetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "Fetch updates for all project repositories",
+	Long: `This command fetches updates from remote for all repositories in configured projects.
+
+Example:
+  eng project fetch              # Fetch all projects
+  eng project fetch -p Echo      # Fetch only the Echo project
+  eng project fetch --dry-run    # Preview what would be fetched`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Start("Fetching project repositories")
+
+		isVerbose := utils.IsVerbose(cmd)
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		projectFilter, _ := cmd.Flags().GetString("project")
+
+		devPath := viper.GetString("git.dev_path")
+		if devPath == "" {
+			log.Error("Development folder path is not set. Use 'eng config git-dev-path' to set it.")
+			return
+		}
+		devPath = os.ExpandEnv(devPath)
+
+		if dryRun {
+			log.Info("Dry run mode - no actual git operations will be performed")
+		}
+
+		projects := config.GetProjects()
+		if len(projects) == 0 {
+			log.Warn("No projects configured. Use 'eng project add' to add a project.")
+			return
+		}
+
+		// Filter by project if specified
+		if projectFilter != "" {
+			filtered := make([]config.Project, 0)
+			for _, p := range projects {
+				if p.Name == projectFilter {
+					filtered = append(filtered, p)
+					break
+				}
+			}
+			if len(filtered) == 0 {
+				log.Error("Project '%s' not found in configuration", projectFilter)
+				return
+			}
+			projects = filtered
+		}
+
+		successCount := 0
+		failedCount := 0
+		skippedCount := 0
+
+		for _, project := range projects {
+			log.Info("Fetching project: %s", project.Name)
+			projectPath := filepath.Join(devPath, project.Name)
+
+			for _, repo := range project.Repos {
+				repoPath, err := repo.GetEffectivePath()
+				if err != nil {
+					log.Error("  Failed to determine path for %s: %s", repo.URL, err)
+					failedCount++
+					continue
+				}
+
+				fullRepoPath := filepath.Join(projectPath, repoPath)
+
+				// Check if repo exists
+				if !isRepoCloned(fullRepoPath) {
+					log.Verbose(isVerbose, "  Skipping %s (not cloned)", repoPath)
+					skippedCount++
+					continue
+				}
+
+				if dryRun {
+					log.Info("  [DRY RUN] Would fetch: %s", repoPath)
+					successCount++
+					continue
+				}
+
+				log.Info("  Fetching %s...", repoPath)
+				if err := fetchRepo(fullRepoPath); err != nil {
+					log.Error("  Failed to fetch %s: %s", repoPath, err)
+					failedCount++
+					continue
+				}
+
+				log.Success("  Fetched %s", repoPath)
+				successCount++
+			}
+		}
+
+		log.Info("")
+		log.Info("Fetch complete: %d successful, %d skipped, %d failed", successCount, skippedCount, failedCount)
+	},
+}
+
+// fetchRepo performs git fetch on a repository.
+func fetchRepo(repoPath string) error {
+	cmd := exec.Command("git", "-C", repoPath, "fetch", "--all", "--prune")
+	cmd.Stdout = log.Writer()
+	cmd.Stderr = log.ErrorWriter()
+	return cmd.Run()
+}

--- a/cmd/project/list.go
+++ b/cmd/project/list.go
@@ -7,9 +7,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/eng618/eng/utils"
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // ListCmd defines the cobra command for listing configured projects.

--- a/cmd/project/list.go
+++ b/cmd/project/list.go
@@ -1,0 +1,133 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/eng618/eng/utils"
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+)
+
+// ListCmd defines the cobra command for listing configured projects.
+// It displays project names, repository counts, and clone status.
+var ListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured projects and their repositories",
+	Long: `This command displays all configured projects and their repositories.
+
+Use the --verbose flag to see detailed information including:
+  - Repository URLs
+  - Clone status (✓ cloned / ✗ missing)
+  - Local paths
+
+Example:
+  eng project list           # Show projects summary
+  eng project list -v        # Show detailed repository information
+  eng project list -p Echo   # Show only the Echo project`,
+	Run: func(cmd *cobra.Command, args []string) {
+		isVerbose := utils.IsVerbose(cmd)
+		projectFilter, _ := cmd.Flags().GetString("project")
+
+		devPath := viper.GetString("git.dev_path")
+		if devPath == "" {
+			log.Warn("Development folder path is not set. Use 'eng config git-dev-path' to set it.")
+			devPath = "(not configured)"
+		} else {
+			devPath = os.ExpandEnv(devPath)
+		}
+
+		projects := config.GetProjects()
+		if len(projects) == 0 {
+			log.Info("No projects configured.")
+			log.Info("Use 'eng project add' to add a project.")
+			return
+		}
+
+		// Filter by project if specified
+		if projectFilter != "" {
+			filtered := make([]config.Project, 0)
+			for _, p := range projects {
+				if p.Name == projectFilter {
+					filtered = append(filtered, p)
+					break
+				}
+			}
+			if len(filtered) == 0 {
+				log.Error("Project '%s' not found in configuration", projectFilter)
+				return
+			}
+			projects = filtered
+		}
+
+		log.Info("Development path: %s", devPath)
+		log.Info("")
+
+		for _, project := range projects {
+			projectPath := filepath.Join(devPath, project.Name)
+
+			if isVerbose {
+				log.Info("Project: %s", project.Name)
+				log.Info("  Path: %s", projectPath)
+				log.Info("  Repositories (%d):", len(project.Repos))
+
+				for _, repo := range project.Repos {
+					repoPath, err := repo.GetEffectivePath()
+					if err != nil {
+						log.Error("    ✗ %s (invalid path)", repo.URL)
+						continue
+					}
+
+					fullRepoPath := filepath.Join(projectPath, repoPath)
+					cloned := isRepoCloned(fullRepoPath)
+
+					if cloned {
+						log.Success("    ✓ %s", repoPath)
+					} else {
+						log.Warn("    ✗ %s (not cloned)", repoPath)
+					}
+
+					log.Info("      URL: %s", repo.URL)
+					if repo.Path != "" {
+						log.Info("      Custom path: %s", repo.Path)
+					}
+				}
+			} else {
+				clonedCount := 0
+				for _, repo := range project.Repos {
+					repoPath, err := repo.GetEffectivePath()
+					if err != nil {
+						continue
+					}
+					fullRepoPath := filepath.Join(projectPath, repoPath)
+					if isRepoCloned(fullRepoPath) {
+						clonedCount++
+					}
+				}
+
+				statusIcon := "✓"
+				if clonedCount < len(project.Repos) {
+					statusIcon = "○"
+				}
+				log.Info("%s %s (%d/%d repos cloned)", statusIcon, project.Name, clonedCount, len(project.Repos))
+			}
+			log.Info("")
+		}
+
+		if !isVerbose {
+			log.Info("Use -v for detailed repository information")
+		}
+	},
+}
+
+// isRepoCloned checks if a repository has been cloned at the given path.
+func isRepoCloned(repoPath string) bool {
+	gitDir := filepath.Join(repoPath, ".git")
+	if info, err := os.Stat(gitDir); err == nil {
+		return info.IsDir()
+	}
+	return false
+}

--- a/cmd/project/list.go
+++ b/cmd/project/list.go
@@ -25,12 +25,12 @@ Use the --verbose flag to see detailed information including:
   - Local paths
 
 Example:
-  eng project list           # Show projects summary
-  eng project list -v        # Show detailed repository information
-  eng project list -p Echo   # Show only the Echo project`,
+  eng project list               # Show projects summary
+  eng project list -v            # Show detailed repository information
+  eng project list -p MyProject  # Show only the specified project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		isVerbose := utils.IsVerbose(cmd)
-		projectFilter, _ := cmd.Flags().GetString("project")
+		projectFilter, _ := cmd.Parent().PersistentFlags().GetString("project")
 
 		devPath := viper.GetString("git.dev_path")
 		if devPath == "" {

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -1,5 +1,5 @@
 // Package project provides cobra commands for managing project-based repository collections.
-// A project is a logical grouping of related repositories (e.g., "Echo" with multiple microservices).
+// A project is a logical grouping of related repositories (e.g., a product with multiple microservices).
 package project
 
 import (
@@ -18,21 +18,20 @@ var ProjectCmd = &cobra.Command{
 	Long: `This command facilitates the management of project-based repository collections.
 
 A project is a logical grouping of related repositories. For example, you might have 
-an "Echo" project containing multiple microservices, or a "Platform" project with 
-shared infrastructure repositories.
+a project containing multiple microservices, or a shared infrastructure project.
 
 Projects are stored in your development folder (configured via 'eng config git-dev-path'),
 with each project having its own subdirectory containing all related repositories.
 
 Example structure:
   ~/Development/
-    Echo/
-      echo-api/
-      echo-web/
-      echo-shared/
-    Platform/
-      platform-core/
-      platform-auth/`,
+    MyProject/
+      api/
+      web/
+      shared/
+    Infrastructure/
+      core/
+      auth/`,
 	Run: func(cmd *cobra.Command, args []string) {
 		showInfo, _ := cmd.Flags().GetBool("info")
 		isVerbose := utils.IsVerbose(cmd)

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/eng618/eng/utils"
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // ProjectCmd serves as the base command for all project management operations.

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -1,0 +1,86 @@
+// Package project provides cobra commands for managing project-based repository collections.
+// A project is a logical grouping of related repositories (e.g., "Echo" with multiple microservices).
+package project
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/eng618/eng/utils"
+	"github.com/eng618/eng/utils/log"
+)
+
+// ProjectCmd serves as the base command for all project management operations.
+// It groups subcommands like setup, list, add, remove, fetch, pull, and sync.
+var ProjectCmd = &cobra.Command{
+	Use:   "project",
+	Short: "Manage project-based repository collections",
+	Long: `This command facilitates the management of project-based repository collections.
+
+A project is a logical grouping of related repositories. For example, you might have 
+an "Echo" project containing multiple microservices, or a "Platform" project with 
+shared infrastructure repositories.
+
+Projects are stored in your development folder (configured via 'eng config git-dev-path'),
+with each project having its own subdirectory containing all related repositories.
+
+Example structure:
+  ~/Development/
+    Echo/
+      echo-api/
+      echo-web/
+      echo-shared/
+    Platform/
+      platform-core/
+      platform-auth/`,
+	Run: func(cmd *cobra.Command, args []string) {
+		showInfo, _ := cmd.Flags().GetBool("info")
+		isVerbose := utils.IsVerbose(cmd)
+
+		if showInfo {
+			log.Info("Current project management configuration:")
+			devPath := viper.GetString("git.dev_path")
+
+			if devPath == "" {
+				log.Warn("  Development Path: Not Set")
+				log.Info("  Use 'eng config git-dev-path' to set your development folder path")
+			} else {
+				log.Info("  Development Path: %s", devPath)
+			}
+
+			// Show configured projects
+			var projects []map[string]interface{}
+			if err := viper.UnmarshalKey("projects", &projects); err == nil && len(projects) > 0 {
+				log.Info("  Configured Projects: %d", len(projects))
+			} else {
+				log.Info("  Configured Projects: 0")
+				log.Info("  Use 'eng project add' to configure a project")
+			}
+			return
+		}
+
+		// If no subcommand is given, print the help information.
+		if len(args) == 0 {
+			log.Verbose(isVerbose, "No subcommand provided, showing help.")
+			err := cmd.Help()
+			cobra.CheckErr(err)
+		} else {
+			log.Verbose(isVerbose, "Subcommand '%s' provided.", args[0])
+		}
+	},
+}
+
+func init() {
+	ProjectCmd.Flags().BoolP("info", "i", false, "Show current project management configuration")
+	ProjectCmd.PersistentFlags().StringP("project", "p", "", "Filter operations to a specific project")
+	ProjectCmd.PersistentFlags().Bool("dry-run", false, "Perform a dry run without making actual changes")
+
+	// Register subcommands
+	ProjectCmd.AddCommand(SetupCmd)
+	ProjectCmd.AddCommand(ListCmd)
+	ProjectCmd.AddCommand(AddCmd)
+	ProjectCmd.AddCommand(RemoveCmd)
+	ProjectCmd.AddCommand(FetchCmd)
+	ProjectCmd.AddCommand(PullCmd)
+	ProjectCmd.AddCommand(SyncCmd)
+}

--- a/cmd/project/project_test.go
+++ b/cmd/project/project_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // setupTestEnvironment creates a temporary workspace and config for testing.

--- a/cmd/project/project_test.go
+++ b/cmd/project/project_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // setupTestEnvironment creates a temporary workspace and config for testing.
-func setupTestEnvironment(t *testing.T) (workspacePath string, configPath string, cleanup func()) {
+func setupTestEnvironment(t *testing.T) (workspacePath, configPath string, cleanup func()) {
 	t.Helper()
 
 	// Create temporary workspace directory

--- a/cmd/project/project_test.go
+++ b/cmd/project/project_test.go
@@ -3,7 +3,6 @@ package project
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -49,26 +48,6 @@ func setupTestEnvironment(t *testing.T) (workspacePath, configPath string, clean
 	}
 
 	return workspace, configPath, cleanup
-}
-
-// setupTestRepo creates a bare git repository that can be cloned.
-func setupTestRepo(t *testing.T, name string) string {
-	t.Helper()
-
-	repoDir, err := os.MkdirTemp("", "test-bare-repo-*")
-	require.NoError(t, err)
-
-	repoPath := filepath.Join(repoDir, name+".git")
-	err = os.MkdirAll(repoPath, 0o755)
-	require.NoError(t, err)
-
-	// Initialize bare repo
-	cmd := exec.Command("git", "init", "--bare")
-	cmd.Dir = repoPath
-	err = cmd.Run()
-	require.NoError(t, err)
-
-	return repoPath
 }
 
 func TestProjectCmd_Help(t *testing.T) {

--- a/cmd/project/project_test.go
+++ b/cmd/project/project_test.go
@@ -1,0 +1,586 @@
+package project
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+)
+
+// setupTestEnvironment creates a temporary workspace and config for testing.
+func setupTestEnvironment(t *testing.T) (workspacePath string, configPath string, cleanup func()) {
+	t.Helper()
+
+	// Create temporary workspace directory
+	workspace, err := os.MkdirTemp("", "project-test-workspace-*")
+	require.NoError(t, err)
+
+	// Create temporary config directory
+	configDir, err := os.MkdirTemp("", "project-test-config-*")
+	require.NoError(t, err)
+
+	configPath = filepath.Join(configDir, ".eng.yaml")
+
+	// Reset viper and configure for test
+	viper.Reset()
+	viper.SetConfigFile(configPath)
+	viper.SetConfigType("yaml")
+
+	// Set git.dev_path to our test workspace
+	viper.Set("git.dev_path", workspace)
+
+	// Create empty config file
+	err = os.WriteFile(configPath, []byte(""), 0o644)
+	require.NoError(t, err)
+
+	cleanup = func() {
+		viper.Reset()
+		os.RemoveAll(workspace)
+		os.RemoveAll(configDir)
+	}
+
+	return workspace, configPath, cleanup
+}
+
+// setupTestRepo creates a bare git repository that can be cloned.
+func setupTestRepo(t *testing.T, name string) string {
+	t.Helper()
+
+	repoDir, err := os.MkdirTemp("", "test-bare-repo-*")
+	require.NoError(t, err)
+
+	repoPath := filepath.Join(repoDir, name+".git")
+	err = os.MkdirAll(repoPath, 0o755)
+	require.NoError(t, err)
+
+	// Initialize bare repo
+	cmd := exec.Command("git", "init", "--bare")
+	cmd.Dir = repoPath
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	return repoPath
+}
+
+func TestProjectCmd_Help(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	ProjectCmd.SetOut(&buf)
+	ProjectCmd.SetErr(&buf)
+
+	// Run without subcommand should show help
+	ProjectCmd.Run(ProjectCmd, []string{})
+
+	// The command should complete without error
+	// (help is shown via cmd.Help() call)
+}
+
+func TestProjectCmd_Info(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	workspace, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	ProjectCmd.SetOut(&buf)
+	ProjectCmd.SetErr(&buf)
+
+	// Set info flag
+	err := ProjectCmd.Flags().Set("info", "true")
+	require.NoError(t, err)
+	defer func() {
+		_ = ProjectCmd.Flags().Set("info", "false")
+	}()
+
+	ProjectCmd.Run(ProjectCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Development Path:")
+	assert.Contains(t, out, workspace)
+	assert.Contains(t, out, "Configured Projects:")
+}
+
+func TestListCmd_EmptyProjects(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	_, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	ListCmd.SetOut(&buf)
+	ListCmd.SetErr(&buf)
+
+	ListCmd.Run(ListCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "No projects configured")
+}
+
+func TestListCmd_WithProjects(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	workspace, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test projects
+	testProjects := []config.Project{
+		{
+			Name: "TestProject",
+			Repos: []config.ProjectRepo{
+				{URL: "git@github.com:org/repo1.git"},
+				{URL: "git@github.com:org/repo2.git"},
+			},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Create one repo directory to simulate partial clone
+	repoDir := filepath.Join(workspace, "TestProject", "repo1", ".git")
+	err = os.MkdirAll(repoDir, 0o755)
+	require.NoError(t, err)
+
+	ListCmd.SetOut(&buf)
+	ListCmd.SetErr(&buf)
+
+	ListCmd.Run(ListCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "TestProject")
+	assert.Contains(t, out, "1/2 repos cloned")
+}
+
+func TestSetupCmd_NoDevPath(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	viper.Reset()
+	// Don't set git.dev_path
+
+	SetupCmd.SetOut(&buf)
+	SetupCmd.SetErr(&buf)
+
+	SetupCmd.Run(SetupCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Development folder path is not set")
+}
+
+func TestSetupCmd_NoProjects(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	_, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	SetupCmd.SetOut(&buf)
+	SetupCmd.SetErr(&buf)
+
+	SetupCmd.Run(SetupCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "No projects configured")
+}
+
+func TestSetupCmd_DryRun(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	_, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test project
+	testProjects := []config.Project{
+		{
+			Name: "DryRunProject",
+			Repos: []config.ProjectRepo{
+				{URL: "git@github.com:org/repo1.git"},
+			},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Set dry-run flag on parent command (persistent flag)
+	err = ProjectCmd.PersistentFlags().Set("dry-run", "true")
+	require.NoError(t, err)
+	defer func() {
+		_ = ProjectCmd.PersistentFlags().Set("dry-run", "false")
+	}()
+
+	SetupCmd.SetOut(&buf)
+	SetupCmd.SetErr(&buf)
+
+	SetupCmd.Run(SetupCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Dry run mode")
+	assert.Contains(t, out, "[DRY RUN]")
+	assert.Contains(t, out, "DryRunProject")
+}
+
+func TestSetupCmd_ProjectFilter_NotFound(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	_, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test project
+	testProjects := []config.Project{
+		{
+			Name:  "ExistingProject",
+			Repos: []config.ProjectRepo{{URL: "git@github.com:org/repo.git"}},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Set project filter to non-existent project (persistent flag on parent)
+	err = ProjectCmd.PersistentFlags().Set("project", "NonExistent")
+	require.NoError(t, err)
+	defer func() {
+		_ = ProjectCmd.PersistentFlags().Set("project", "")
+	}()
+
+	SetupCmd.SetOut(&buf)
+	SetupCmd.SetErr(&buf)
+
+	SetupCmd.Run(SetupCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "not found")
+}
+
+func TestSetupCmd_SkipsExistingRepos(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	workspace, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test project
+	testProjects := []config.Project{
+		{
+			Name: "TestProject",
+			Repos: []config.ProjectRepo{
+				{URL: "git@github.com:org/existing-repo.git"},
+			},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Create the repo directory with .git to simulate already cloned
+	repoDir := filepath.Join(workspace, "TestProject", "existing-repo", ".git")
+	err = os.MkdirAll(repoDir, 0o755)
+	require.NoError(t, err)
+
+	SetupCmd.SetOut(&buf)
+	SetupCmd.SetErr(&buf)
+
+	// Reset any lingering flags
+	_ = SetupCmd.Flags().Set("dry-run", "false")
+	_ = SetupCmd.Flags().Set("project", "")
+
+	SetupCmd.Run(SetupCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Already present: 1")
+}
+
+func TestFetchCmd_NoDevPath(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	viper.Reset()
+
+	FetchCmd.SetOut(&buf)
+	FetchCmd.SetErr(&buf)
+
+	FetchCmd.Run(FetchCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Development folder path is not set")
+}
+
+func TestPullCmd_NoDevPath(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	viper.Reset()
+
+	PullCmd.SetOut(&buf)
+	PullCmd.SetErr(&buf)
+
+	PullCmd.Run(PullCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Development folder path is not set")
+}
+
+func TestSyncCmd_NoDevPath(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	viper.Reset()
+
+	SyncCmd.SetOut(&buf)
+	SyncCmd.SetErr(&buf)
+
+	SyncCmd.Run(SyncCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Development folder path is not set")
+}
+
+func TestIsRepoCloned(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-is-cloned-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Test non-existent path
+	assert.False(t, isRepoCloned(filepath.Join(tmpDir, "nonexistent")))
+
+	// Test directory without .git
+	noGitDir := filepath.Join(tmpDir, "no-git")
+	err = os.MkdirAll(noGitDir, 0o755)
+	require.NoError(t, err)
+	assert.False(t, isRepoCloned(noGitDir))
+
+	// Test directory with .git file (not directory)
+	gitFileDir := filepath.Join(tmpDir, "git-file")
+	err = os.MkdirAll(gitFileDir, 0o755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(gitFileDir, ".git"), []byte("gitdir: ../other"), 0o644)
+	require.NoError(t, err)
+	assert.False(t, isRepoCloned(gitFileDir)) // .git must be a directory
+
+	// Test directory with .git directory
+	gitDirPath := filepath.Join(tmpDir, "has-git")
+	err = os.MkdirAll(filepath.Join(gitDirPath, ".git"), 0o755)
+	require.NoError(t, err)
+	assert.True(t, isRepoCloned(gitDirPath))
+}
+
+func TestCloneRepository_InvalidURL(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-clone-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	destPath := filepath.Join(tmpDir, "test-repo")
+
+	// Try to clone with invalid URL - should fail with helpful error
+	err = cloneRepository("not-a-valid-url", destPath)
+	assert.Error(t, err)
+}
+
+func TestFetchCmd_DryRun(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	workspace, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test project
+	testProjects := []config.Project{
+		{
+			Name: "FetchProject",
+			Repos: []config.ProjectRepo{
+				{URL: "git@github.com:org/repo1.git"},
+			},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Create the repo directory with .git to simulate cloned
+	repoDir := filepath.Join(workspace, "FetchProject", "repo1", ".git")
+	err = os.MkdirAll(repoDir, 0o755)
+	require.NoError(t, err)
+
+	// Set dry-run flag on parent command (persistent flag)
+	err = ProjectCmd.PersistentFlags().Set("dry-run", "true")
+	require.NoError(t, err)
+	defer func() {
+		_ = ProjectCmd.PersistentFlags().Set("dry-run", "false")
+	}()
+
+	FetchCmd.SetOut(&buf)
+	FetchCmd.SetErr(&buf)
+
+	FetchCmd.Run(FetchCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Dry run mode")
+	assert.Contains(t, out, "[DRY RUN]")
+}
+
+func TestPullCmd_DryRun(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	workspace, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test project
+	testProjects := []config.Project{
+		{
+			Name: "PullProject",
+			Repos: []config.ProjectRepo{
+				{URL: "git@github.com:org/repo1.git"},
+			},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Create the repo directory with .git to simulate cloned
+	repoDir := filepath.Join(workspace, "PullProject", "repo1", ".git")
+	err = os.MkdirAll(repoDir, 0o755)
+	require.NoError(t, err)
+
+	// Set dry-run flag on parent command (persistent flag)
+	err = ProjectCmd.PersistentFlags().Set("dry-run", "true")
+	require.NoError(t, err)
+	defer func() {
+		_ = ProjectCmd.PersistentFlags().Set("dry-run", "false")
+	}()
+
+	PullCmd.SetOut(&buf)
+	PullCmd.SetErr(&buf)
+
+	PullCmd.Run(PullCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Dry run mode")
+	assert.Contains(t, out, "[DRY RUN]")
+}
+
+func TestSyncCmd_DryRun(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	workspace, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test project
+	testProjects := []config.Project{
+		{
+			Name: "SyncProject",
+			Repos: []config.ProjectRepo{
+				{URL: "git@github.com:org/repo1.git"},
+			},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Create the repo directory with .git to simulate cloned
+	repoDir := filepath.Join(workspace, "SyncProject", "repo1", ".git")
+	err = os.MkdirAll(repoDir, 0o755)
+	require.NoError(t, err)
+
+	// Set dry-run flag on parent command (persistent flag)
+	err = ProjectCmd.PersistentFlags().Set("dry-run", "true")
+	require.NoError(t, err)
+	defer func() {
+		_ = ProjectCmd.PersistentFlags().Set("dry-run", "false")
+	}()
+
+	SyncCmd.SetOut(&buf)
+	SyncCmd.SetErr(&buf)
+
+	SyncCmd.Run(SyncCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Dry run mode")
+	assert.Contains(t, out, "[DRY RUN]")
+}
+
+func TestListCmd_VerboseOutput(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	workspace, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Add test projects
+	testProjects := []config.Project{
+		{
+			Name: "VerboseProject",
+			Repos: []config.ProjectRepo{
+				{URL: "git@github.com:org/repo1.git"},
+				{URL: "git@github.com:org/repo2.git", Path: "custom-name"},
+			},
+		},
+	}
+	err := config.SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Create one repo directory
+	repoDir := filepath.Join(workspace, "VerboseProject", "repo1", ".git")
+	err = os.MkdirAll(repoDir, 0o755)
+	require.NoError(t, err)
+
+	// Enable verbose via viper (simulating -v flag)
+	viper.Set("verbose", true)
+	defer viper.Set("verbose", false)
+
+	ListCmd.SetOut(&buf)
+	ListCmd.SetErr(&buf)
+
+	ListCmd.Run(ListCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "VerboseProject")
+	assert.Contains(t, out, "Repositories")
+	assert.Contains(t, out, "git@github.com:org/repo1.git")
+	assert.Contains(t, out, "Custom path: custom-name")
+	// Check for status indicators
+	assert.True(t, strings.Contains(out, "✓") || strings.Contains(out, "✗"))
+}
+
+func TestRemoveCmd_NoProjects(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetWriters(&buf, &buf)
+	defer log.ResetWriters()
+
+	_, _, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	RemoveCmd.SetOut(&buf)
+	RemoveCmd.SetErr(&buf)
+
+	RemoveCmd.Run(RemoveCmd, []string{})
+
+	out := buf.String()
+	assert.Contains(t, out, "No projects configured")
+}

--- a/cmd/project/pull.go
+++ b/cmd/project/pull.go
@@ -7,10 +7,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/eng618/eng/utils"
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
-	"github.com/eng618/eng/utils/repo"
+	"github.com/eng618/eng/internal/utils"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
+	"github.com/eng618/eng/internal/utils/repo"
 )
 
 // PullCmd defines the cobra command for pulling all project repositories.

--- a/cmd/project/pull.go
+++ b/cmd/project/pull.go
@@ -131,7 +131,13 @@ Example:
 		}
 
 		log.Info("")
-		log.Info("Pull complete: %d successful, %d skipped, %d dirty, %d failed", successCount, skippedCount, dirtyCount, failedCount)
+		log.Info(
+			"Pull complete: %d successful, %d skipped, %d dirty, %d failed",
+			successCount,
+			skippedCount,
+			dirtyCount,
+			failedCount,
+		)
 
 		if dirtyCount > 0 {
 			log.Warn("Some repositories were skipped due to uncommitted changes.")

--- a/cmd/project/pull.go
+++ b/cmd/project/pull.go
@@ -1,9 +1,11 @@
 package project
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -115,7 +117,7 @@ Example:
 				log.Info("  Pulling %s...", repoPath)
 				if err := repo.PullLatestCode(fullRepoPath); err != nil {
 					// Check if it's just "already up to date"
-					if err.Error() == "already up-to-date" {
+					if errors.Is(err, git.NoErrAlreadyUpToDate) {
 						log.Info("  %s is already up to date", repoPath)
 						successCount++
 						continue

--- a/cmd/project/pull.go
+++ b/cmd/project/pull.go
@@ -1,0 +1,141 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/eng618/eng/utils"
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/utils/repo"
+)
+
+// PullCmd defines the cobra command for pulling all project repositories.
+// It runs git pull on all repositories in configured projects.
+var PullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Pull updates for all project repositories",
+	Long: `This command pulls the latest changes from remote for all repositories in configured projects.
+
+Note: Repositories with uncommitted changes will be skipped.
+
+Example:
+  eng project pull              # Pull all projects
+  eng project pull -p Echo      # Pull only the Echo project
+  eng project pull --dry-run    # Preview what would be pulled`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Start("Pulling project repositories")
+
+		isVerbose := utils.IsVerbose(cmd)
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		projectFilter, _ := cmd.Flags().GetString("project")
+
+		devPath := viper.GetString("git.dev_path")
+		if devPath == "" {
+			log.Error("Development folder path is not set. Use 'eng config git-dev-path' to set it.")
+			return
+		}
+		devPath = os.ExpandEnv(devPath)
+
+		if dryRun {
+			log.Info("Dry run mode - no actual git operations will be performed")
+		}
+
+		projects := config.GetProjects()
+		if len(projects) == 0 {
+			log.Warn("No projects configured. Use 'eng project add' to add a project.")
+			return
+		}
+
+		// Filter by project if specified
+		if projectFilter != "" {
+			filtered := make([]config.Project, 0)
+			for _, p := range projects {
+				if p.Name == projectFilter {
+					filtered = append(filtered, p)
+					break
+				}
+			}
+			if len(filtered) == 0 {
+				log.Error("Project '%s' not found in configuration", projectFilter)
+				return
+			}
+			projects = filtered
+		}
+
+		successCount := 0
+		failedCount := 0
+		skippedCount := 0
+		dirtyCount := 0
+
+		for _, project := range projects {
+			log.Info("Pulling project: %s", project.Name)
+			projectPath := filepath.Join(devPath, project.Name)
+
+			for _, r := range project.Repos {
+				repoPath, err := r.GetEffectivePath()
+				if err != nil {
+					log.Error("  Failed to determine path for %s: %s", r.URL, err)
+					failedCount++
+					continue
+				}
+
+				fullRepoPath := filepath.Join(projectPath, repoPath)
+
+				// Check if repo exists
+				if !isRepoCloned(fullRepoPath) {
+					log.Verbose(isVerbose, "  Skipping %s (not cloned)", repoPath)
+					skippedCount++
+					continue
+				}
+
+				// Check for uncommitted changes
+				isDirty, err := repo.IsDirty(fullRepoPath)
+				if err != nil {
+					log.Error("  Failed to check status of %s: %s", repoPath, err)
+					failedCount++
+					continue
+				}
+
+				if isDirty {
+					log.Warn("  Skipping %s (has uncommitted changes)", repoPath)
+					dirtyCount++
+					continue
+				}
+
+				if dryRun {
+					log.Info("  [DRY RUN] Would pull: %s", repoPath)
+					successCount++
+					continue
+				}
+
+				log.Info("  Pulling %s...", repoPath)
+				if err := repo.PullLatestCode(fullRepoPath); err != nil {
+					// Check if it's just "already up to date"
+					if err.Error() == "already up-to-date" {
+						log.Info("  %s is already up to date", repoPath)
+						successCount++
+						continue
+					}
+					log.Error("  Failed to pull %s: %s", repoPath, err)
+					failedCount++
+					continue
+				}
+
+				log.Success("  Pulled %s", repoPath)
+				successCount++
+			}
+		}
+
+		log.Info("")
+		log.Info("Pull complete: %d successful, %d skipped, %d dirty, %d failed", successCount, skippedCount, dirtyCount, failedCount)
+
+		if dirtyCount > 0 {
+			log.Warn("Some repositories were skipped due to uncommitted changes.")
+			log.Info("Commit or stash your changes, then run again.")
+		}
+	},
+}

--- a/cmd/project/remove.go
+++ b/cmd/project/remove.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"strconv"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 
@@ -93,8 +95,8 @@ Example:
 			// Confirm project removal
 			var confirm bool
 			confirmPrompt := &survey.Confirm{
-				Message: "Remove project '" + projectName + "' with " + string(
-					rune('0'+len(project.Repos)),
+				Message: "Remove project '" + projectName + "' with " + strconv.Itoa(
+					len(project.Repos),
 				) + " repositories?",
 				Default: false,
 			}

--- a/cmd/project/remove.go
+++ b/cmd/project/remove.go
@@ -93,7 +93,9 @@ Example:
 			// Confirm project removal
 			var confirm bool
 			confirmPrompt := &survey.Confirm{
-				Message: "Remove project '" + projectName + "' with " + string(rune('0'+len(project.Repos))) + " repositories?",
+				Message: "Remove project '" + projectName + "' with " + string(
+					rune('0'+len(project.Repos)),
+				) + " repositories?",
 				Default: false,
 			}
 			if err := survey.AskOne(confirmPrompt, &confirm); err != nil {

--- a/cmd/project/remove.go
+++ b/cmd/project/remove.go
@@ -4,8 +4,8 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // RemoveCmd defines the cobra command for removing projects or repositories.

--- a/cmd/project/remove.go
+++ b/cmd/project/remove.go
@@ -19,8 +19,8 @@ Note: This only removes the entry from your configuration.
 It does NOT delete any files from disk.
 
 Example:
-  eng project remove              # Interactive removal
-  eng project remove -p Echo      # Remove from the Echo project`,
+  eng project remove                  # Interactive removal
+  eng project remove -p MyProject     # Remove from the specified project`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Start("Removing project configuration")
 

--- a/cmd/project/remove.go
+++ b/cmd/project/remove.go
@@ -1,0 +1,157 @@
+package project
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+)
+
+// RemoveCmd defines the cobra command for removing projects or repositories.
+// It provides interactive prompts for safe removal.
+var RemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a project or repository from configuration",
+	Long: `This command removes a project or a repository from a project's configuration.
+
+Note: This only removes the entry from your configuration. 
+It does NOT delete any files from disk.
+
+Example:
+  eng project remove              # Interactive removal
+  eng project remove -p Echo      # Remove from the Echo project`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Start("Removing project configuration")
+
+		projectFilter, _ := cmd.Flags().GetString("project")
+
+		projects := config.GetProjects()
+		if len(projects) == 0 {
+			log.Info("No projects configured.")
+			return
+		}
+
+		existingNames := config.GetProjectNames()
+
+		var projectName string
+
+		if projectFilter != "" {
+			// Use the specified project
+			projectName = projectFilter
+			found := false
+			for _, name := range existingNames {
+				if name == projectFilter {
+					found = true
+					break
+				}
+			}
+			if !found {
+				log.Error("Project '%s' not found", projectFilter)
+				return
+			}
+		} else {
+			// Interactive project selection
+			prompt := &survey.Select{
+				Message: "Select a project:",
+				Options: existingNames,
+			}
+			if err := survey.AskOne(prompt, &projectName); err != nil {
+				log.Error("Prompt failed: %s", err)
+				return
+			}
+		}
+
+		// Get the project
+		project := config.GetProjectByName(projectName)
+		if project == nil {
+			log.Error("Project '%s' not found", projectName)
+			return
+		}
+
+		// Ask what to remove
+		options := []string{"[Remove entire project]"}
+		for _, repo := range project.Repos {
+			path, err := repo.GetEffectivePath()
+			if err != nil {
+				path = repo.URL
+			}
+			options = append(options, path)
+		}
+
+		var selection string
+		selectPrompt := &survey.Select{
+			Message: "What would you like to remove?",
+			Options: options,
+		}
+		if err := survey.AskOne(selectPrompt, &selection); err != nil {
+			log.Error("Prompt failed: %s", err)
+			return
+		}
+
+		if selection == "[Remove entire project]" {
+			// Confirm project removal
+			var confirm bool
+			confirmPrompt := &survey.Confirm{
+				Message: "Remove project '" + projectName + "' with " + string(rune('0'+len(project.Repos))) + " repositories?",
+				Default: false,
+			}
+			if err := survey.AskOne(confirmPrompt, &confirm); err != nil {
+				log.Error("Prompt failed: %s", err)
+				return
+			}
+
+			if !confirm {
+				log.Info("Canceled.")
+				return
+			}
+
+			if err := config.RemoveProject(projectName); err != nil {
+				log.Error("Failed to remove project: %s", err)
+				return
+			}
+
+			log.Success("Removed project '%s' from configuration", projectName)
+			log.Info("Note: Files on disk were not deleted.")
+		} else {
+			// Find the repo URL for the selected path
+			var repoURL string
+			for _, repo := range project.Repos {
+				path, _ := repo.GetEffectivePath()
+				if path == selection {
+					repoURL = repo.URL
+					break
+				}
+			}
+
+			if repoURL == "" {
+				log.Error("Repository not found")
+				return
+			}
+
+			// Confirm repo removal
+			var confirm bool
+			confirmPrompt := &survey.Confirm{
+				Message: "Remove repository '" + selection + "' from project '" + projectName + "'?",
+				Default: false,
+			}
+			if err := survey.AskOne(confirmPrompt, &confirm); err != nil {
+				log.Error("Prompt failed: %s", err)
+				return
+			}
+
+			if !confirm {
+				log.Info("Canceled.")
+				return
+			}
+
+			if err := config.RemoveRepoFromProject(projectName, repoURL); err != nil {
+				log.Error("Failed to remove repository: %s", err)
+				return
+			}
+
+			log.Success("Removed repository '%s' from project '%s'", selection, projectName)
+			log.Info("Note: Files on disk were not deleted.")
+		}
+	},
+}

--- a/cmd/project/setup.go
+++ b/cmd/project/setup.go
@@ -1,0 +1,184 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/eng618/eng/utils"
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+)
+
+// SetupCmd defines the cobra command for setting up project repositories.
+// It ensures project directories exist and clones any missing repositories.
+var SetupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Setup project directories and clone missing repositories",
+	Long: `This command ensures all configured projects have their directory structure 
+set up and all repositories are cloned.
+
+It is safe to run multiple times - existing repositories will be skipped.
+Use this command when:
+  - Setting up a new development machine
+  - A new repository has been added to a project's configuration
+  - You want to verify all project repos are present
+
+Example:
+  eng project setup              # Setup all projects
+  eng project setup -p Echo      # Setup only the Echo project
+  eng project setup --dry-run    # Preview what would be done`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Start("Setting up project repositories")
+
+		isVerbose := utils.IsVerbose(cmd)
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		projectFilter, _ := cmd.Flags().GetString("project")
+
+		devPath := viper.GetString("git.dev_path")
+		if devPath == "" {
+			log.Error("Development folder path is not set. Use 'eng config git-dev-path' to set it.")
+			return
+		}
+		devPath = os.ExpandEnv(devPath)
+
+		log.Verbose(isVerbose, "Development path: %s", devPath)
+
+		if dryRun {
+			log.Info("Dry run mode - no actual changes will be made")
+		}
+
+		projects := config.GetProjects()
+		if len(projects) == 0 {
+			log.Warn("No projects configured. Use 'eng project add' to add a project.")
+			return
+		}
+
+		// Filter by project if specified
+		if projectFilter != "" {
+			filtered := make([]config.Project, 0)
+			for _, p := range projects {
+				if p.Name == projectFilter {
+					filtered = append(filtered, p)
+					break
+				}
+			}
+			if len(filtered) == 0 {
+				log.Error("Project '%s' not found in configuration", projectFilter)
+				return
+			}
+			projects = filtered
+		}
+
+		totalRepos := 0
+		clonedCount := 0
+		skippedCount := 0
+		failedCount := 0
+
+		for _, project := range projects {
+			log.Info("Processing project: %s", project.Name)
+
+			projectPath := filepath.Join(devPath, project.Name)
+
+			// Ensure project directory exists
+			if dryRun {
+				log.Info("  [DRY RUN] Would ensure directory exists: %s", projectPath)
+			} else {
+				if err := os.MkdirAll(projectPath, 0o755); err != nil {
+					log.Error("  Failed to create project directory: %s", err)
+					continue
+				}
+				log.Verbose(isVerbose, "  Project directory ready: %s", projectPath)
+			}
+
+			for _, repo := range project.Repos {
+				totalRepos++
+
+				repoPath, err := repo.GetEffectivePath()
+				if err != nil {
+					log.Error("  Failed to determine path for %s: %s", repo.URL, err)
+					failedCount++
+					continue
+				}
+
+				fullRepoPath := filepath.Join(projectPath, repoPath)
+
+				// Check if repo already exists
+				if _, err := os.Stat(filepath.Join(fullRepoPath, ".git")); err == nil {
+					log.Verbose(isVerbose, "  Repository already exists: %s", repoPath)
+					skippedCount++
+					continue
+				}
+
+				if dryRun {
+					log.Info("  [DRY RUN] Would clone %s to %s", repo.URL, fullRepoPath)
+					clonedCount++
+					continue
+				}
+
+				log.Info("  Cloning %s...", repoPath)
+
+				// Clone the repository
+				if err := cloneRepository(repo.URL, fullRepoPath); err != nil {
+					log.Error("  Failed to clone %s: %s", repo.URL, err)
+					failedCount++
+					continue
+				}
+
+				log.Success("  Cloned %s", repoPath)
+				clonedCount++
+			}
+		}
+
+		log.Info("")
+		log.Info("Setup complete:")
+		log.Info("  Total repositories: %d", totalRepos)
+		log.Info("  Cloned: %d", clonedCount)
+		log.Info("  Already present: %d", skippedCount)
+		if failedCount > 0 {
+			log.Warn("  Failed: %d", failedCount)
+		}
+
+		if failedCount > 0 {
+			log.Warn("Some repositories failed to clone. Check the output above for details.")
+			log.Info("Common issues:")
+			log.Info("  - SSH key not configured for the repository host")
+			log.Info("  - Repository URL is incorrect")
+			log.Info("  - Network connectivity issues")
+		} else if !dryRun && clonedCount > 0 {
+			log.Success("All project repositories set up successfully!")
+		}
+	},
+}
+
+// cloneRepository clones a git repository to the specified path.
+// It uses go-git for the clone operation and provides informative error messages.
+func cloneRepository(url, destPath string) error {
+	_, err := git.PlainClone(destPath, false, &git.CloneOptions{
+		URL:      url,
+		Progress: log.Writer(),
+	})
+	if err != nil {
+		errStr := strings.ToLower(err.Error())
+		// Provide more helpful error messages for common issues
+		switch {
+		case errStr == "repository already exists":
+			return fmt.Errorf("repository already exists at %s", destPath)
+		case strings.Contains(errStr, "authentication"):
+			return fmt.Errorf("authentication failed - ensure your SSH keys are configured or use HTTPS with credentials: %w", err)
+		case strings.Contains(errStr, "could not read username"):
+			return fmt.Errorf("credentials required - for HTTPS URLs, configure git credential helper or use SSH: %w", err)
+		case strings.Contains(errStr, "ssh:"):
+			return fmt.Errorf("SSH error - ensure your SSH keys are loaded (ssh-add) and have access to the repository: %w", err)
+		default:
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/project/setup.go
+++ b/cmd/project/setup.go
@@ -170,11 +170,20 @@ func cloneRepository(url, destPath string) error {
 		case errStr == "repository already exists":
 			return fmt.Errorf("repository already exists at %s", destPath)
 		case strings.Contains(errStr, "authentication"):
-			return fmt.Errorf("authentication failed - ensure your SSH keys are configured or use HTTPS with credentials: %w", err)
+			return fmt.Errorf(
+				"authentication failed - ensure your SSH keys are configured or use HTTPS with credentials: %w",
+				err,
+			)
 		case strings.Contains(errStr, "could not read username"):
-			return fmt.Errorf("credentials required - for HTTPS URLs, configure git credential helper or use SSH: %w", err)
+			return fmt.Errorf(
+				"credentials required - for HTTPS URLs, configure git credential helper or use SSH: %w",
+				err,
+			)
 		case strings.Contains(errStr, "ssh:"):
-			return fmt.Errorf("SSH error - ensure your SSH keys are loaded (ssh-add) and have access to the repository: %w", err)
+			return fmt.Errorf(
+				"SSH error - ensure your SSH keys are loaded (ssh-add) and have access to the repository: %w",
+				err,
+			)
 		default:
 			return err
 		}

--- a/cmd/project/setup.go
+++ b/cmd/project/setup.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -167,7 +168,7 @@ func cloneRepository(url, destPath string) error {
 		errStr := strings.ToLower(err.Error())
 		// Provide more helpful error messages for common issues
 		switch {
-		case errStr == "repository already exists":
+		case errors.Is(err, git.ErrRepositoryAlreadyExists):
 			return fmt.Errorf("repository already exists at %s", destPath)
 		case strings.Contains(errStr, "authentication"):
 			return fmt.Errorf(

--- a/cmd/project/setup.go
+++ b/cmd/project/setup.go
@@ -10,9 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/eng618/eng/utils"
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // SetupCmd defines the cobra command for setting up project repositories.

--- a/cmd/project/setup.go
+++ b/cmd/project/setup.go
@@ -30,15 +30,15 @@ Use this command when:
   - You want to verify all project repos are present
 
 Example:
-  eng project setup              # Setup all projects
-  eng project setup -p Echo      # Setup only the Echo project
-  eng project setup --dry-run    # Preview what would be done`,
+  eng project setup                  # Setup all projects
+  eng project setup -p MyProject     # Setup only the specified project
+  eng project setup --dry-run        # Preview what would be done`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Start("Setting up project repositories")
 
 		isVerbose := utils.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		projectFilter, _ := cmd.Flags().GetString("project")
+		dryRun, _ := cmd.Parent().PersistentFlags().GetBool("dry-run")
+		projectFilter, _ := cmd.Parent().PersistentFlags().GetString("project")
 
 		devPath := viper.GetString("git.dev_path")
 		if devPath == "" {

--- a/cmd/project/sync.go
+++ b/cmd/project/sync.go
@@ -1,9 +1,11 @@
 package project
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
+	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -131,7 +133,7 @@ Example:
 
 				// Pull
 				if err := repo.PullLatestCode(fullRepoPath); err != nil {
-					if err.Error() == "already up-to-date" {
+					if errors.Is(err, git.NoErrAlreadyUpToDate) {
 						log.Verbose(isVerbose, "    Already up to date")
 						pullSuccess++
 						continue

--- a/cmd/project/sync.go
+++ b/cmd/project/sync.go
@@ -7,10 +7,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/eng618/eng/utils"
-	"github.com/eng618/eng/utils/config"
-	"github.com/eng618/eng/utils/log"
-	"github.com/eng618/eng/utils/repo"
+	"github.com/eng618/eng/internal/utils"
+	"github.com/eng618/eng/internal/utils/config"
+	"github.com/eng618/eng/internal/utils/log"
+	"github.com/eng618/eng/internal/utils/repo"
 )
 
 // SyncCmd defines the cobra command for syncing all project repositories.

--- a/cmd/project/sync.go
+++ b/cmd/project/sync.go
@@ -149,7 +149,13 @@ Example:
 		log.Info("")
 		log.Info("Sync complete:")
 		log.Info("  Fetch: %d successful, %d failed", fetchSuccess, fetchFailed)
-		log.Info("  Pull:  %d successful, %d failed, %d dirty, %d skipped", pullSuccess, pullFailed, dirtyCount, skippedCount)
+		log.Info(
+			"  Pull:  %d successful, %d failed, %d dirty, %d skipped",
+			pullSuccess,
+			pullFailed,
+			dirtyCount,
+			skippedCount,
+		)
 
 		if dirtyCount > 0 {
 			log.Warn("Some repositories were not pulled due to uncommitted changes.")

--- a/cmd/project/sync.go
+++ b/cmd/project/sync.go
@@ -1,0 +1,158 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/eng618/eng/utils"
+	"github.com/eng618/eng/utils/config"
+	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/utils/repo"
+)
+
+// SyncCmd defines the cobra command for syncing all project repositories.
+// It fetches and pulls all repositories in configured projects.
+var SyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync all project repositories (fetch + pull)",
+	Long: `This command synchronizes all repositories in configured projects by:
+  1. Fetching updates from remote (git fetch --all --prune)
+  2. Pulling changes for the current branch (git pull)
+
+Repositories with uncommitted changes will have fetch performed but pull will be skipped.
+
+Example:
+  eng project sync              # Sync all projects
+  eng project sync -p Echo      # Sync only the Echo project
+  eng project sync --dry-run    # Preview what would be synced`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Start("Syncing project repositories")
+
+		isVerbose := utils.IsVerbose(cmd)
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		projectFilter, _ := cmd.Flags().GetString("project")
+
+		devPath := viper.GetString("git.dev_path")
+		if devPath == "" {
+			log.Error("Development folder path is not set. Use 'eng config git-dev-path' to set it.")
+			return
+		}
+		devPath = os.ExpandEnv(devPath)
+
+		if dryRun {
+			log.Info("Dry run mode - no actual git operations will be performed")
+		}
+
+		projects := config.GetProjects()
+		if len(projects) == 0 {
+			log.Warn("No projects configured. Use 'eng project add' to add a project.")
+			return
+		}
+
+		// Filter by project if specified
+		if projectFilter != "" {
+			filtered := make([]config.Project, 0)
+			for _, p := range projects {
+				if p.Name == projectFilter {
+					filtered = append(filtered, p)
+					break
+				}
+			}
+			if len(filtered) == 0 {
+				log.Error("Project '%s' not found in configuration", projectFilter)
+				return
+			}
+			projects = filtered
+		}
+
+		fetchSuccess := 0
+		fetchFailed := 0
+		pullSuccess := 0
+		pullFailed := 0
+		skippedCount := 0
+		dirtyCount := 0
+
+		for _, project := range projects {
+			log.Info("Syncing project: %s", project.Name)
+			projectPath := filepath.Join(devPath, project.Name)
+
+			for _, r := range project.Repos {
+				repoPath, err := r.GetEffectivePath()
+				if err != nil {
+					log.Error("  Failed to determine path for %s: %s", r.URL, err)
+					fetchFailed++
+					pullFailed++
+					continue
+				}
+
+				fullRepoPath := filepath.Join(projectPath, repoPath)
+
+				// Check if repo exists
+				if !isRepoCloned(fullRepoPath) {
+					log.Verbose(isVerbose, "  Skipping %s (not cloned)", repoPath)
+					skippedCount++
+					continue
+				}
+
+				if dryRun {
+					log.Info("  [DRY RUN] Would sync: %s", repoPath)
+					fetchSuccess++
+					pullSuccess++
+					continue
+				}
+
+				log.Info("  Syncing %s...", repoPath)
+
+				// Fetch
+				if err := fetchRepo(fullRepoPath); err != nil {
+					log.Error("    Fetch failed: %s", err)
+					fetchFailed++
+				} else {
+					log.Verbose(isVerbose, "    Fetched successfully")
+					fetchSuccess++
+				}
+
+				// Check for uncommitted changes before pull
+				isDirty, err := repo.IsDirty(fullRepoPath)
+				if err != nil {
+					log.Error("    Failed to check status: %s", err)
+					pullFailed++
+					continue
+				}
+
+				if isDirty {
+					log.Warn("    Skipping pull (has uncommitted changes)")
+					dirtyCount++
+					continue
+				}
+
+				// Pull
+				if err := repo.PullLatestCode(fullRepoPath); err != nil {
+					if err.Error() == "already up-to-date" {
+						log.Verbose(isVerbose, "    Already up to date")
+						pullSuccess++
+						continue
+					}
+					log.Error("    Pull failed: %s", err)
+					pullFailed++
+					continue
+				}
+
+				log.Success("    Synced %s", repoPath)
+				pullSuccess++
+			}
+		}
+
+		log.Info("")
+		log.Info("Sync complete:")
+		log.Info("  Fetch: %d successful, %d failed", fetchSuccess, fetchFailed)
+		log.Info("  Pull:  %d successful, %d failed, %d dirty, %d skipped", pullSuccess, pullFailed, dirtyCount, skippedCount)
+
+		if dirtyCount > 0 {
+			log.Warn("Some repositories were not pulled due to uncommitted changes.")
+		}
+	},
+}

--- a/cmd/project/sync.go
+++ b/cmd/project/sync.go
@@ -25,15 +25,15 @@ var SyncCmd = &cobra.Command{
 Repositories with uncommitted changes will have fetch performed but pull will be skipped.
 
 Example:
-  eng project sync              # Sync all projects
-  eng project sync -p Echo      # Sync only the Echo project
-  eng project sync --dry-run    # Preview what would be synced`,
+  eng project sync                  # Sync all projects
+  eng project sync -p MyProject     # Sync only the specified project
+  eng project sync --dry-run        # Preview what would be synced`,
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Start("Syncing project repositories")
 
 		isVerbose := utils.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		projectFilter, _ := cmd.Flags().GetString("project")
+		dryRun, _ := cmd.Parent().PersistentFlags().GetBool("dry-run")
+		projectFilter, _ := cmd.Parent().PersistentFlags().GetString("project")
 
 		devPath := viper.GetString("git.dev_path")
 		if devPath == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ import (
 	"github.com/eng618/eng/cmd/files"
 	"github.com/eng618/eng/cmd/git"
 	"github.com/eng618/eng/cmd/gitlab"
-	"github.com/eng618/eng/cmd/parable_bloom"
+	"github.com/eng618/eng/cmd/project"
 	"github.com/eng618/eng/cmd/system"
 	"github.com/eng618/eng/cmd/ts"
 	"github.com/eng618/eng/cmd/version"
@@ -101,7 +101,7 @@ func init() {
 	rootCmd.AddCommand(files.FilesCmd)
 	rootCmd.AddCommand(gitlab.GitLabCmd)
 	rootCmd.AddCommand(git.GitCmd)
-	rootCmd.AddCommand(parable_bloom.ParableBloomCmd)
+	rootCmd.AddCommand(project.ProjectCmd)
 	rootCmd.AddCommand(system.SystemCmd)
 	rootCmd.AddCommand(ts.TailscaleCmd)
 	rootCmd.AddCommand(version.VersionCmd)

--- a/cmd/system/proxy_test.go
+++ b/cmd/system/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/eng618/eng/internal/utils/config"
@@ -21,12 +22,18 @@ func TestListProxyConfigurations(t *testing.T) {
 	}
 	viper.Set("proxies", proxies)
 
+	// Create a test command with the required flags
+	testCmd := &cobra.Command{}
+	testCmd.Flags().Bool("compact", false, "")
+	testCmd.Flags().Bool("env", false, "")
+	testCmd.Flags().Bool("lowercase-env", false, "")
+
 	// Capture stdout
 	old := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	listProxyConfigurations(nil)
+	listProxyConfigurations(testCmd)
 
 	w.Close()
 	os.Stdout = old
@@ -38,8 +45,9 @@ func TestListProxyConfigurations(t *testing.T) {
 	if !strings.Contains(output, "Test Proxy") {
 		t.Error("Expected output to contain 'Test Proxy'")
 	}
-	if !strings.Contains(output, "1. ★ Test Proxy") {
-		t.Error("Expected output to show proxy 1 as enabled with star marker")
+	// The format is now: "1. ★ Test Proxy (http://test:8080) [ACTIVE]"
+	if !strings.Contains(output, "1.") || !strings.Contains(output, "ACTIVE") {
+		t.Error("Expected output to show proxy 1 as active with [ACTIVE]")
 	}
 }
 

--- a/cmd/system/setup.go
+++ b/cmd/system/setup.go
@@ -331,8 +331,10 @@ func generateSSHKey(sshKeyPath string, verbose bool) error {
 	if err := os.MkdirAll(sshDir, 0o700); err != nil {
 		return fmt.Errorf("failed to create SSH directory: %w", err)
 	}
+	log.Verbose(verbose, "SSH directory ready at %s", sshDir)
 
 	// Generate SSH key
+	log.Verbose(verbose, "Generating SSH key with command: ssh-keygen -t ed25519 -f %s -N '' -C github", sshKeyPath)
 	cmd := execCommand("ssh-keygen", "-t", "ed25519", "-f", sshKeyPath, "-N", "", "-C", "github")
 	cmd.Stdout = log.Writer()
 	cmd.Stderr = log.ErrorWriter()
@@ -360,6 +362,7 @@ func storeSSHKeyInBitwarden(sshKeyPath string, verbose bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to read SSH private key: %w", err)
 	}
+	log.Verbose(verbose, "Read SSH private key from %s", sshKeyPath)
 
 	// Read the public key
 	publicKeyPath := sshKeyPath + ".pub"

--- a/internal/utils/config/migration.go
+++ b/internal/utils/config/migration.go
@@ -45,6 +45,13 @@ func MigrateConfig() {
 		changed = true
 	}
 
+	// Initialize projects key if not set (no migration needed, just ensure key exists)
+	if !viper.IsSet("projects") {
+		viper.Set("projects", []interface{}{})
+		log.Verbose(isVerbose, "Initialized empty projects configuration")
+		changed = true
+	}
+
 	if changed {
 		if err := viper.WriteConfig(); err != nil {
 			log.Warn("Failed to save migrated configuration: %v", err)

--- a/internal/utils/config/project.go
+++ b/internal/utils/config/project.go
@@ -1,0 +1,206 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/viper"
+
+	"github.com/eng618/eng/utils/log"
+)
+
+// Project represents a collection of related repositories.
+type Project struct {
+	Name  string        `mapstructure:"name"`
+	Repos []ProjectRepo `mapstructure:"repos"`
+}
+
+// ProjectRepo represents a single repository within a project.
+type ProjectRepo struct {
+	URL  string `mapstructure:"url"`
+	Path string `mapstructure:"path,omitempty"` // Optional, defaults to repo name from URL
+}
+
+// GetProjects retrieves the list of configured projects from the config file.
+func GetProjects() []Project {
+	var projects []Project
+
+	if !viper.IsSet("projects") {
+		// Initialize with empty array if not set
+		viper.Set("projects", []Project{})
+		if err := viper.WriteConfig(); err != nil {
+			log.Warn("Error initializing projects config: %v", err)
+		}
+		return projects
+	}
+
+	if err := viper.UnmarshalKey("projects", &projects); err != nil {
+		log.Error("Failed to unmarshal projects configuration: %v", err)
+		return []Project{}
+	}
+
+	return projects
+}
+
+// GetProjectByName retrieves a specific project by name.
+// Returns nil if not found.
+func GetProjectByName(name string) *Project {
+	projects := GetProjects()
+	for i := range projects {
+		if strings.EqualFold(projects[i].Name, name) {
+			return &projects[i]
+		}
+	}
+	return nil
+}
+
+// SaveProjects persists the list of projects to the config file.
+func SaveProjects(projects []Project) error {
+	viper.Set("projects", projects)
+	if err := viper.WriteConfig(); err != nil {
+		return fmt.Errorf("failed to save projects configuration: %w", err)
+	}
+	return nil
+}
+
+// AddProject adds a new project or updates an existing one.
+// If a project with the same name exists, it updates it; otherwise, it appends.
+func AddProject(project Project) error {
+	projects := GetProjects()
+
+	// Check if project already exists
+	for i := range projects {
+		if strings.EqualFold(projects[i].Name, project.Name) {
+			projects[i] = project
+			return SaveProjects(projects)
+		}
+	}
+
+	// Append new project
+	projects = append(projects, project)
+	return SaveProjects(projects)
+}
+
+// AddRepoToProject adds a repository to an existing project.
+// Returns an error if the project doesn't exist.
+func AddRepoToProject(projectName string, repo ProjectRepo) error {
+	projects := GetProjects()
+
+	for i := range projects {
+		if strings.EqualFold(projects[i].Name, projectName) {
+			// Check if repo already exists
+			for _, existingRepo := range projects[i].Repos {
+				if existingRepo.URL == repo.URL {
+					return fmt.Errorf("repository %s already exists in project %s", repo.URL, projectName)
+				}
+			}
+			projects[i].Repos = append(projects[i].Repos, repo)
+			return SaveProjects(projects)
+		}
+	}
+
+	return fmt.Errorf("project %s not found", projectName)
+}
+
+// RemoveProject removes a project from the configuration.
+func RemoveProject(projectName string) error {
+	projects := GetProjects()
+	newProjects := make([]Project, 0, len(projects))
+
+	found := false
+	for _, p := range projects {
+		if strings.EqualFold(p.Name, projectName) {
+			found = true
+			continue
+		}
+		newProjects = append(newProjects, p)
+	}
+
+	if !found {
+		return fmt.Errorf("project %s not found", projectName)
+	}
+
+	return SaveProjects(newProjects)
+}
+
+// RemoveRepoFromProject removes a repository from a project.
+func RemoveRepoFromProject(projectName, repoURL string) error {
+	projects := GetProjects()
+
+	for i := range projects {
+		if strings.EqualFold(projects[i].Name, projectName) {
+			newRepos := make([]ProjectRepo, 0, len(projects[i].Repos))
+			found := false
+
+			for _, repo := range projects[i].Repos {
+				if repo.URL == repoURL {
+					found = true
+					continue
+				}
+				newRepos = append(newRepos, repo)
+			}
+
+			if !found {
+				return fmt.Errorf("repository %s not found in project %s", repoURL, projectName)
+			}
+
+			projects[i].Repos = newRepos
+			return SaveProjects(projects)
+		}
+	}
+
+	return fmt.Errorf("project %s not found", projectName)
+}
+
+// RepoNameFromURL extracts the repository name from a git URL.
+// Supports both SSH (git@host:path/repo.git) and HTTPS (https://host/path/repo.git) formats.
+func RepoNameFromURL(repoURL string) (string, error) {
+	// SSH format: git@host:path/repo.git or ssh://git@host/path/repo.git
+	sshPattern := regexp.MustCompile(`^(?:git|ssh)@[^:]+:(.+?)(?:\.git)?$`)
+	if matches := sshPattern.FindStringSubmatch(repoURL); len(matches) == 2 {
+		path := strings.TrimSuffix(matches[1], ".git")
+		return filepath.Base(path), nil
+	}
+
+	// SSH with protocol: ssh://git@host/path/repo.git
+	sshProtoPattern := regexp.MustCompile(`^ssh://[^/]+/(.+?)(?:\.git)?$`)
+	if matches := sshProtoPattern.FindStringSubmatch(repoURL); len(matches) == 2 {
+		path := strings.TrimSuffix(matches[1], ".git")
+		return filepath.Base(path), nil
+	}
+
+	// HTTPS format: https://host/path/repo.git
+	if strings.HasPrefix(repoURL, "http://") || strings.HasPrefix(repoURL, "https://") {
+		u, err := url.Parse(repoURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse URL: %w", err)
+		}
+		path := strings.TrimPrefix(u.Path, "/")
+		path = strings.TrimSuffix(path, ".git")
+		return filepath.Base(path), nil
+	}
+
+	return "", fmt.Errorf("unsupported URL format: %s", repoURL)
+}
+
+// GetEffectivePath returns the effective path for a repo.
+// If Path is set, it uses that; otherwise, it derives from the URL.
+func (r *ProjectRepo) GetEffectivePath() (string, error) {
+	if r.Path != "" {
+		return r.Path, nil
+	}
+	return RepoNameFromURL(r.URL)
+}
+
+// GetProjectNames returns a list of all configured project names.
+func GetProjectNames() []string {
+	projects := GetProjects()
+	names := make([]string, len(projects))
+	for i, p := range projects {
+		names[i] = p.Name
+	}
+	return names
+}

--- a/internal/utils/config/project.go
+++ b/internal/utils/config/project.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/eng618/eng/utils/log"
+	"github.com/eng618/eng/internal/utils/log"
 )
 
 // Project represents a collection of related repositories.

--- a/internal/utils/config/project_test.go
+++ b/internal/utils/config/project_test.go
@@ -1,0 +1,395 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestConfig creates a temporary config file for testing.
+func setupTestConfig(t *testing.T) (string, func()) {
+	t.Helper()
+
+	// Create a temporary directory for the config file
+	tmpDir, err := os.MkdirTemp("", "project-config-test-*")
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tmpDir, ".eng.yaml")
+
+	// Reset viper and configure for test
+	viper.Reset()
+	viper.SetConfigFile(configPath)
+	viper.SetConfigType("yaml")
+
+	// Create empty config file
+	err = os.WriteFile(configPath, []byte(""), 0o644)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		viper.Reset()
+		os.RemoveAll(tmpDir)
+	}
+
+	return configPath, cleanup
+}
+
+func TestRepoNameFromURL(t *testing.T) {
+	testCases := []struct {
+		name        string
+		url         string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "SSH format with .git",
+			url:      "git@github.com:org/my-repo.git",
+			expected: "my-repo",
+		},
+		{
+			name:     "SSH format without .git",
+			url:      "git@github.com:org/my-repo",
+			expected: "my-repo",
+		},
+		{
+			name:     "SSH format with nested path",
+			url:      "git@gitlab.com:group/subgroup/my-repo.git",
+			expected: "my-repo",
+		},
+		{
+			name:     "HTTPS format with .git",
+			url:      "https://github.com/org/my-repo.git",
+			expected: "my-repo",
+		},
+		{
+			name:     "HTTPS format without .git",
+			url:      "https://github.com/org/my-repo",
+			expected: "my-repo",
+		},
+		{
+			name:     "HTTPS format with nested path",
+			url:      "https://gitlab.com/group/subgroup/my-repo.git",
+			expected: "my-repo",
+		},
+		{
+			name:     "HTTP format",
+			url:      "http://github.com/org/my-repo.git",
+			expected: "my-repo",
+		},
+		{
+			name:        "Invalid format",
+			url:         "not-a-valid-url",
+			expectError: true,
+		},
+		{
+			name:        "Empty string",
+			url:         "",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := RepoNameFromURL(tc.url)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestProjectRepo_GetEffectivePath(t *testing.T) {
+	testCases := []struct {
+		name        string
+		repo        ProjectRepo
+		expected    string
+		expectError bool
+	}{
+		{
+			name: "Custom path set",
+			repo: ProjectRepo{
+				URL:  "git@github.com:org/my-repo.git",
+				Path: "custom-name",
+			},
+			expected: "custom-name",
+		},
+		{
+			name: "No custom path - derive from URL",
+			repo: ProjectRepo{
+				URL:  "git@github.com:org/my-repo.git",
+				Path: "",
+			},
+			expected: "my-repo",
+		},
+		{
+			name: "Invalid URL with no custom path",
+			repo: ProjectRepo{
+				URL:  "invalid",
+				Path: "",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := tc.repo.GetEffectivePath()
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetProjects_EmptyConfig(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	projects := GetProjects()
+	assert.Empty(t, projects)
+}
+
+func TestSaveAndGetProjects(t *testing.T) {
+	configPath, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Read the config file
+	err := viper.ReadInConfig()
+	if err != nil {
+		// File might be empty, that's ok
+		t.Logf("Note: %v", err)
+	}
+
+	// Create test projects
+	testProjects := []Project{
+		{
+			Name: "ProjectA",
+			Repos: []ProjectRepo{
+				{URL: "git@github.com:org/repo1.git"},
+				{URL: "git@github.com:org/repo2.git", Path: "custom"},
+			},
+		},
+		{
+			Name: "ProjectB",
+			Repos: []ProjectRepo{
+				{URL: "https://github.com/org/repo3.git"},
+			},
+		},
+	}
+
+	// Save projects
+	err = SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Verify file was written
+	_, err = os.Stat(configPath)
+	require.NoError(t, err)
+
+	// Read back projects
+	projects := GetProjects()
+	assert.Len(t, projects, 2)
+	assert.Equal(t, "ProjectA", projects[0].Name)
+	assert.Len(t, projects[0].Repos, 2)
+	assert.Equal(t, "ProjectB", projects[1].Name)
+}
+
+func TestGetProjectByName(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	testProjects := []Project{
+		{Name: "Alpha", Repos: []ProjectRepo{{URL: "git@github.com:org/alpha.git"}}},
+		{Name: "Beta", Repos: []ProjectRepo{{URL: "git@github.com:org/beta.git"}}},
+	}
+
+	err := SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Test finding existing project
+	project := GetProjectByName("Alpha")
+	require.NotNil(t, project)
+	assert.Equal(t, "Alpha", project.Name)
+
+	// Test case-insensitive search
+	project = GetProjectByName("alpha")
+	require.NotNil(t, project)
+	assert.Equal(t, "Alpha", project.Name)
+
+	// Test non-existent project
+	project = GetProjectByName("NonExistent")
+	assert.Nil(t, project)
+}
+
+func TestAddProject(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Add first project
+	project1 := Project{
+		Name:  "First",
+		Repos: []ProjectRepo{{URL: "git@github.com:org/first.git"}},
+	}
+	err := AddProject(project1)
+	require.NoError(t, err)
+
+	projects := GetProjects()
+	assert.Len(t, projects, 1)
+
+	// Add second project
+	project2 := Project{
+		Name:  "Second",
+		Repos: []ProjectRepo{{URL: "git@github.com:org/second.git"}},
+	}
+	err = AddProject(project2)
+	require.NoError(t, err)
+
+	projects = GetProjects()
+	assert.Len(t, projects, 2)
+
+	// Update existing project (same name)
+	project1Updated := Project{
+		Name: "First",
+		Repos: []ProjectRepo{
+			{URL: "git@github.com:org/first.git"},
+			{URL: "git@github.com:org/first-new.git"},
+		},
+	}
+	err = AddProject(project1Updated)
+	require.NoError(t, err)
+
+	projects = GetProjects()
+	assert.Len(t, projects, 2) // Still 2 projects
+	first := GetProjectByName("First")
+	require.NotNil(t, first)
+	assert.Len(t, first.Repos, 2) // But first now has 2 repos
+}
+
+func TestAddRepoToProject(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Setup initial project
+	project := Project{
+		Name:  "TestProject",
+		Repos: []ProjectRepo{{URL: "git@github.com:org/repo1.git"}},
+	}
+	err := AddProject(project)
+	require.NoError(t, err)
+
+	// Add repo to existing project
+	newRepo := ProjectRepo{URL: "git@github.com:org/repo2.git", Path: "custom-path"}
+	err = AddRepoToProject("TestProject", newRepo)
+	require.NoError(t, err)
+
+	p := GetProjectByName("TestProject")
+	require.NotNil(t, p)
+	assert.Len(t, p.Repos, 2)
+	assert.Equal(t, "custom-path", p.Repos[1].Path)
+
+	// Try to add duplicate repo
+	err = AddRepoToProject("TestProject", newRepo)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	// Try to add to non-existent project
+	err = AddRepoToProject("NonExistent", newRepo)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRemoveProject(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Setup projects
+	testProjects := []Project{
+		{Name: "Keep", Repos: []ProjectRepo{{URL: "git@github.com:org/keep.git"}}},
+		{Name: "Remove", Repos: []ProjectRepo{{URL: "git@github.com:org/remove.git"}}},
+	}
+	err := SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	// Remove project
+	err = RemoveProject("Remove")
+	require.NoError(t, err)
+
+	projects := GetProjects()
+	assert.Len(t, projects, 1)
+	assert.Equal(t, "Keep", projects[0].Name)
+
+	// Try to remove non-existent project
+	err = RemoveProject("NonExistent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRemoveRepoFromProject(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Setup project with multiple repos
+	project := Project{
+		Name: "TestProject",
+		Repos: []ProjectRepo{
+			{URL: "git@github.com:org/repo1.git"},
+			{URL: "git@github.com:org/repo2.git"},
+			{URL: "git@github.com:org/repo3.git"},
+		},
+	}
+	err := AddProject(project)
+	require.NoError(t, err)
+
+	// Remove middle repo
+	err = RemoveRepoFromProject("TestProject", "git@github.com:org/repo2.git")
+	require.NoError(t, err)
+
+	p := GetProjectByName("TestProject")
+	require.NotNil(t, p)
+	assert.Len(t, p.Repos, 2)
+	assert.Equal(t, "git@github.com:org/repo1.git", p.Repos[0].URL)
+	assert.Equal(t, "git@github.com:org/repo3.git", p.Repos[1].URL)
+
+	// Try to remove non-existent repo
+	err = RemoveRepoFromProject("TestProject", "git@github.com:org/nonexistent.git")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// Try to remove from non-existent project
+	err = RemoveRepoFromProject("NonExistent", "git@github.com:org/repo1.git")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestGetProjectNames(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	// Empty initially
+	names := GetProjectNames()
+	assert.Empty(t, names)
+
+	// Add projects
+	testProjects := []Project{
+		{Name: "Zebra", Repos: []ProjectRepo{{URL: "git@github.com:org/z.git"}}},
+		{Name: "Alpha", Repos: []ProjectRepo{{URL: "git@github.com:org/a.git"}}},
+		{Name: "Beta", Repos: []ProjectRepo{{URL: "git@github.com:org/b.git"}}},
+	}
+	err := SaveProjects(testProjects)
+	require.NoError(t, err)
+
+	names = GetProjectNames()
+	assert.Len(t, names, 3)
+	// Names should be in the order they were saved
+	assert.Equal(t, []string{"Zebra", "Alpha", "Beta"}, names)
+}


### PR DESCRIPTION
Add new 'eng project' command for managing collections of related
repositories grouped by project (e.g., Echo, NEN). This enables
efficient setup and synchronization of multi-repo workspaces.

New subcommands:
- setup: Clone missing repos and create project directories
- list: Display projects with clone status indicators
- add: Interactive prompts to add projects/repos to config
- remove: Remove projects/repos from config (preserves files)
- fetch: Fetch all repos across projects
- pull: Pull all repos (skips dirty working trees)
- sync: Combined fetch + pull operation

Features:
- Safe to re-run (skips already-cloned repos)
- Graceful auth error messages for SSH/HTTPS failures
- Dry-run mode for all operations (--dry-run)
- Project filtering (-p/--project flag)
- Auto-derived directory names from repo URLs
- Optional custom path overrides in config