### PR TITLE
🧪 test: add rigorous edge-case testing for ExtractSSHKeyFromItem

### DIFF
--- a/internal/utils/bitwarden_test.go
+++ b/internal/utils/bitwarden_test.go
@@ -137,6 +137,75 @@ func TestExtractSSHKeyFromItem(t *testing.T) {
 			expectedKey: "",
 			expectError: true,
 		},
+		{
+			name: "Native SSH key payload with whitespace PrivateKey should fall back to notes",
+			item: BitwardenItem{
+				Name: "SSH Key Empty",
+				SSHKey: &BitwardenSSHKey{
+					PrivateKey: "   \n\t  ",
+				},
+				Notes: "-----BEGIN OPENSSH PRIVATE KEY-----\nnotes key data\n-----END OPENSSH PRIVATE KEY-----",
+			},
+			expectedKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nnotes key data\n-----END OPENSSH PRIVATE KEY-----",
+			expectError: false,
+		},
+		{
+			name: "Custom field with invalid name but valid format should be ignored",
+			item: BitwardenItem{
+				Name: "SSH Key Invalid Field",
+				Fields: []BitwardenField{
+					{
+						Name:  "Random Field",
+						Value: "-----BEGIN OPENSSH PRIVATE KEY-----\nrandom key data\n-----END OPENSSH PRIVATE KEY-----",
+						Type:  0,
+					},
+				},
+			},
+			expectedKey: "",
+			expectError: true,
+		},
+		{
+			name: "Custom field with valid name but invalid format should be ignored",
+			item: BitwardenItem{
+				Name: "SSH Key Invalid Format Field",
+				Fields: []BitwardenField{
+					{
+						Name:  "Private Key",
+						Value: "just some random text without markers",
+						Type:  0,
+					},
+				},
+			},
+			expectedKey: "",
+			expectError: true,
+		},
+		{
+			name: "Login password lacking proper format should fall through to error",
+			item: BitwardenItem{
+				Name: "Login password invalid format",
+				Login: &BitwardenLogin{
+					Password: "regularpassword",
+				},
+			},
+			expectedKey: "",
+			expectError: true,
+		},
+		{
+			name: "Notes lacking proper format should fall through to next checks",
+			item: BitwardenItem{
+				Name:  "Notes invalid format, fallback to field",
+				Notes: "just some notes without keys",
+				Fields: []BitwardenField{
+					{
+						Name:  "private",
+						Value: "-----BEGIN OPENSSH PRIVATE KEY-----\nfield key data\n-----END OPENSSH PRIVATE KEY-----",
+						Type:  0,
+					},
+				},
+			},
+			expectedKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nfield key data\n-----END OPENSSH PRIVATE KEY-----",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
🎯 **What:** Improved the testing gap by adding multiple edge-case scenarios to `TestExtractSSHKeyFromItem` in `internal/utils/bitwarden_test.go`.
📊 **Coverage:** Now tests for native SSH keys with only whitespace, incorrect formatting in various fallback fields (notes, login passwords, custom fields), and ensures the correct extraction logic executes in proper order.
✨ **Result:** Enhanced the reliability of `ExtractSSHKeyFromItem` by ensuring fallthrough logic and edge cases are effectively tested and behave as expected.

---
*PR created automatically by Jules for task [14499793384463671576](https://jules.google.com/task/14499793384463671576) started by @eng618*