### PR TITLE
🧪 Add tests for GridSizeForLevel pseudo-random generation

### DIFF
--- a/cmd/parable_bloom/common/modules_test.go
+++ b/cmd/parable_bloom/common/modules_test.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"math"
+	"testing"
+)
+
+func TestGridSizeForLevel(t *testing.T) {
+	t.Run("Determinism", func(t *testing.T) {
+		levelID := 42
+		difficulty := "Flourishing"
+		expected := GridSizeForLevel(levelID, difficulty)
+
+		for i := 0; i < 10; i++ {
+			result := GridSizeForLevel(levelID, difficulty)
+			if result != expected {
+				t.Errorf("Expected deterministic result %v, got %v on iteration %d", expected, result, i)
+			}
+		}
+	})
+
+	t.Run("Bounds checking across difficulties", func(t *testing.T) {
+		difficulties := []string{"Tutorial", "Seedling", "Sprout", "Nurturing", "Flourishing", "Transcendent"}
+
+		for _, diff := range difficulties {
+			t.Run(diff, func(t *testing.T) {
+				ranges := GridSizeRanges[diff]
+
+				// Test several levels to ensure coverage within bounds
+				for levelID := 1; levelID <= 100; levelID++ {
+					result := GridSizeForLevel(levelID, diff)
+					width, height := result[0], result[1]
+
+					if width < ranges.MinW || width > ranges.MaxW {
+						t.Errorf("Difficulty %s, Level %d: Width %d is out of bounds [%d, %d]", diff, levelID, width, ranges.MinW, ranges.MaxW)
+					}
+					if height < ranges.MinH || height > ranges.MaxH {
+						t.Errorf("Difficulty %s, Level %d: Height %d is out of bounds [%d, %d]", diff, levelID, height, ranges.MinH, ranges.MaxH)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("Fallback for unknown difficulty", func(t *testing.T) {
+		levelID := 15
+		unknownResult := GridSizeForLevel(levelID, "UnknownDifficulty")
+		seedlingResult := GridSizeForLevel(levelID, "Seedling")
+
+		if unknownResult != seedlingResult {
+			t.Errorf("Expected unknown difficulty to fallback to Seedling. Got %v, expected %v", unknownResult, seedlingResult)
+		}
+
+		ranges := GridSizeRanges["Seedling"]
+		width, height := unknownResult[0], unknownResult[1]
+		if width < ranges.MinW || width > ranges.MaxW || height < ranges.MinH || height > ranges.MaxH {
+			t.Errorf("Fallback result out of Seedling bounds. Result: %v, Bounds: [%d-%d, %d-%d]", unknownResult, ranges.MinW, ranges.MaxW, ranges.MinH, ranges.MaxH)
+		}
+	})
+
+	t.Run("Edge Cases: Level ID clamping", func(t *testing.T) {
+		// Negative levelID should be clamped to 0
+		negResult := GridSizeForLevel(-5, "Seedling")
+		zeroResult := GridSizeForLevel(0, "Seedling")
+		if negResult != zeroResult {
+			t.Errorf("Expected levelID < 0 to be clamped to 0. Got %v, expected %v", negResult, zeroResult)
+		}
+
+		// Extremely large levelID should be clamped or wrapped without panicking
+		// Note: The implementation clamps to math.MaxUint32 (if it exceeds int(math.MaxUint32), which happens on 64-bit systems)
+		// On 32-bit systems, int is 32-bit, so it might not exceed int(math.MaxUint32).
+		// We'll test with math.MaxInt and math.MaxInt32 and ensure they don't panic and return valid sizes
+		largeResults := [][2]int{
+			GridSizeForLevel(math.MaxInt32, "Sprout"),
+			GridSizeForLevel(math.MaxInt, "Sprout"),
+		}
+
+		ranges := GridSizeRanges["Sprout"]
+		for _, result := range largeResults {
+			width, height := result[0], result[1]
+			if width < ranges.MinW || width > ranges.MaxW || height < ranges.MinH || height > ranges.MaxH {
+				t.Errorf("Edge case result out of bounds. Result: %v, Bounds: [%d-%d, %d-%d]", result, ranges.MinW, ranges.MaxW, ranges.MinH, ranges.MaxH)
+			}
+		}
+	})
+}

--- a/cmd/parable_bloom/common/modules_test.go
+++ b/cmd/parable_bloom/common/modules_test.go
@@ -14,13 +14,25 @@ func TestGridSizeForLevel(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			result := GridSizeForLevel(levelID, difficulty)
 			if result != expected {
-				t.Errorf("Expected deterministic result %v, got %v on iteration %d", expected, result, i)
+				t.Errorf(
+					"Expected deterministic result %v, got %v on iteration %d",
+					expected,
+					result,
+					i,
+				)
 			}
 		}
 	})
 
 	t.Run("Bounds checking across difficulties", func(t *testing.T) {
-		difficulties := []string{"Tutorial", "Seedling", "Sprout", "Nurturing", "Flourishing", "Transcendent"}
+		difficulties := []string{
+			"Tutorial",
+			"Seedling",
+			"Sprout",
+			"Nurturing",
+			"Flourishing",
+			"Transcendent",
+		}
 
 		for _, diff := range difficulties {
 			t.Run(diff, func(t *testing.T) {
@@ -32,10 +44,24 @@ func TestGridSizeForLevel(t *testing.T) {
 					width, height := result[0], result[1]
 
 					if width < ranges.MinW || width > ranges.MaxW {
-						t.Errorf("Difficulty %s, Level %d: Width %d is out of bounds [%d, %d]", diff, levelID, width, ranges.MinW, ranges.MaxW)
+						t.Errorf(
+							"Difficulty %s, Level %d: Width %d is out of bounds [%d, %d]",
+							diff,
+							levelID,
+							width,
+							ranges.MinW,
+							ranges.MaxW,
+						)
 					}
 					if height < ranges.MinH || height > ranges.MaxH {
-						t.Errorf("Difficulty %s, Level %d: Height %d is out of bounds [%d, %d]", diff, levelID, height, ranges.MinH, ranges.MaxH)
+						t.Errorf(
+							"Difficulty %s, Level %d: Height %d is out of bounds [%d, %d]",
+							diff,
+							levelID,
+							height,
+							ranges.MinH,
+							ranges.MaxH,
+						)
 					}
 				}
 			})
@@ -48,13 +74,25 @@ func TestGridSizeForLevel(t *testing.T) {
 		seedlingResult := GridSizeForLevel(levelID, "Seedling")
 
 		if unknownResult != seedlingResult {
-			t.Errorf("Expected unknown difficulty to fallback to Seedling. Got %v, expected %v", unknownResult, seedlingResult)
+			t.Errorf(
+				"Expected unknown difficulty to fallback to Seedling. Got %v, expected %v",
+				unknownResult,
+				seedlingResult,
+			)
 		}
 
 		ranges := GridSizeRanges["Seedling"]
 		width, height := unknownResult[0], unknownResult[1]
-		if width < ranges.MinW || width > ranges.MaxW || height < ranges.MinH || height > ranges.MaxH {
-			t.Errorf("Fallback result out of Seedling bounds. Result: %v, Bounds: [%d-%d, %d-%d]", unknownResult, ranges.MinW, ranges.MaxW, ranges.MinH, ranges.MaxH)
+		if width < ranges.MinW || width > ranges.MaxW || height < ranges.MinH ||
+			height > ranges.MaxH {
+			t.Errorf(
+				"Fallback result out of Seedling bounds. Result: %v, Bounds: [%d-%d, %d-%d]",
+				unknownResult,
+				ranges.MinW,
+				ranges.MaxW,
+				ranges.MinH,
+				ranges.MaxH,
+			)
 		}
 	})
 
@@ -63,7 +101,11 @@ func TestGridSizeForLevel(t *testing.T) {
 		negResult := GridSizeForLevel(-5, "Seedling")
 		zeroResult := GridSizeForLevel(0, "Seedling")
 		if negResult != zeroResult {
-			t.Errorf("Expected levelID < 0 to be clamped to 0. Got %v, expected %v", negResult, zeroResult)
+			t.Errorf(
+				"Expected levelID < 0 to be clamped to 0. Got %v, expected %v",
+				negResult,
+				zeroResult,
+			)
 		}
 
 		// Extremely large levelID should be clamped or wrapped without panicking
@@ -78,8 +120,16 @@ func TestGridSizeForLevel(t *testing.T) {
 		ranges := GridSizeRanges["Sprout"]
 		for _, result := range largeResults {
 			width, height := result[0], result[1]
-			if width < ranges.MinW || width > ranges.MaxW || height < ranges.MinH || height > ranges.MaxH {
-				t.Errorf("Edge case result out of bounds. Result: %v, Bounds: [%d-%d, %d-%d]", result, ranges.MinW, ranges.MaxW, ranges.MinH, ranges.MaxH)
+			if width < ranges.MinW || width > ranges.MaxW || height < ranges.MinH ||
+				height > ranges.MaxH {
+				t.Errorf(
+					"Edge case result out of bounds. Result: %v, Bounds: [%d-%d, %d-%d]",
+					result,
+					ranges.MinW,
+					ranges.MaxW,
+					ranges.MinH,
+					ranges.MaxH,
+				)
 			}
 		}
 	})

--- a/fix.diff
+++ b/fix.diff
@@ -1,0 +1,19 @@
+<<<<<<< SEARCH
+		// Extremely large levelID should be clamped or wrapped without panicking
+		// Note: The implementation clamps to math.MaxUint32 (if it exceeds int(math.MaxUint32), which happens on 64-bit systems)
+		// On 32-bit systems, int is 32-bit, so it might not exceed int(math.MaxUint32).
+		// We'll test with math.MaxInt64 and math.MaxInt32 and ensure they don't panic and return valid sizes
+		largeResults := [][2]int{
+			GridSizeForLevel(math.MaxInt32, "Sprout"),
+			GridSizeForLevel(math.MaxInt64, "Sprout"),
+		}
+=======
+		// Extremely large levelID should be clamped or wrapped without panicking
+		// Note: The implementation clamps to math.MaxUint32 (if it exceeds int(math.MaxUint32), which happens on 64-bit systems)
+		// On 32-bit systems, int is 32-bit, so it might not exceed int(math.MaxUint32).
+		// We'll test with math.MaxInt and math.MaxInt32 and ensure they don't panic and return valid sizes
+		largeResults := [][2]int{
+			GridSizeForLevel(math.MaxInt32, "Sprout"),
+			GridSizeForLevel(math.MaxInt, "Sprout"),
+		}
+>>>>>>> REPLACE


### PR DESCRIPTION
🎯 **What:** The `GridSizeForLevel` function relies on deterministic pseudo-random logic with FNV-1a to calculate grid dimensions based on a level ID and difficulty. This logic previously had no dedicated tests.
📊 **Coverage:** This PR introduces `TestGridSizeForLevel` in `cmd/parable_bloom/common/modules_test.go`, which covers:
- **Determinism**: Ensures multiple calls with the same inputs return the exact same output.
- **Bounds Checking**: Iterates through multiple level IDs for each difficulty to guarantee dimensions strictly stay within defined minimums and maximums (`GridSizeRanges`).
- **Fallback Behavior**: Verifies that passing an unknown difficulty safely defaults to 'Seedling' parameters.
- **Edge Cases**: Validates proper clamping behavior for negative level IDs and extreme/maximum integer level IDs.
✨ **Result:** Improved test coverage and reliability for grid generation logic, reducing the likelihood of regressions or unintended out-of-bounds dimensions.

---
*PR created automatically by Jules for task [9958539006565370909](https://jules.google.com/task/9958539006565370909) started by @eng618*