### PR TITLE
🧹 refactor(git): dry-up duplicate setup and header logic across git commands

### DIFF
--- a/cmd/git/branch_all.go
+++ b/cmd/git/branch_all.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/repo"
 )
@@ -19,24 +18,20 @@ var BranchAllCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Start("Checking current branch of all git repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
-
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			log.Error("Failed to find git repositories: %s", err)
 			return
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 

--- a/cmd/git/clean_all.go
+++ b/cmd/git/clean_all.go
@@ -7,12 +7,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/eng618/eng/internal/asdf"
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/ui"
 	"github.com/eng618/eng/internal/ui/theme"
@@ -24,33 +22,23 @@ var CleanAllCmd = &cobra.Command{
 	Short: "Clean untracked files in all git repositories in development folder",
 	Long:  `This command removes untracked files and directories for all git repositories found in your development folder.`,
 	Run: func(cmd *cobra.Command, _args []string) {
-		headerStyle := lipgloss.NewStyle().
-			Bold(true).
-			Foreground(theme.Primary).
-			MarginBottom(1)
-		if !ui.DisableProgress {
-			fmt.Println(headerStyle.Render("🧹 Clean Development Repositories"))
-		}
+		printHeader("🧹 Clean Development Repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		force, _ := cmd.Flags().GetBool("force")
-		directories, _ := cmd.Flags().GetBool("directories")
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
+		force, _ := cmd.Flags().GetBool("force")
+		directories, _ := cmd.Flags().GetBool("directories")
 
 		var scanSpinner *ui.Spinner
 		if !ui.DisableProgress {
-			scanSpinner = ui.NewSpinner(fmt.Sprintf("Scanning git repositories in %s for untracked files...", devPath))
+			scanSpinner = ui.NewSpinner(fmt.Sprintf("Scanning git repositories in %s for untracked files...", setup.DevPath))
 		}
 
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			if scanSpinner != nil {
 				scanSpinner.Stop()
@@ -117,7 +105,7 @@ var CleanAllCmd = &cobra.Command{
 			fmt.Println(theme.InfoBox.Render(strings.Join(boxLines, "\n")))
 		}
 
-		if dryRun {
+		if setup.DryRun {
 			theme.InfoMessage(
 				fmt.Sprintf(
 					"Dry run complete. Previewed cleaning %d repository(ies) reclaiming %s disk space.",

--- a/cmd/git/clean_all.go
+++ b/cmd/git/clean_all.go
@@ -35,7 +35,10 @@ var CleanAllCmd = &cobra.Command{
 
 		var scanSpinner *ui.Spinner
 		if !ui.DisableProgress {
-			scanSpinner = ui.NewSpinner(fmt.Sprintf("Scanning git repositories in %s for untracked files...", setup.DevPath))
+			scanSpinner = ui.NewSpinner(fmt.Sprintf(
+				"Scanning git repositories in %s for untracked files...",
+				setup.DevPath,
+			))
 		}
 
 		repos, err := findGitRepositories(setup.DevPath)

--- a/cmd/git/fetch_all.go
+++ b/cmd/git/fetch_all.go
@@ -6,11 +6,9 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/ui"
 	"github.com/eng618/eng/internal/ui/theme"
@@ -23,37 +21,22 @@ var FetchAllCmd = &cobra.Command{
 	Short: "Fetch all git repositories in development folder",
 	Long:  `This command fetches updates from remote for all git repositories found in your development folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		headerStyle := lipgloss.NewStyle().
-			Bold(true).
-			Foreground(theme.Primary).
-			MarginBottom(1)
-		if !ui.DisableProgress {
-			fmt.Fprintln(log.Out, headerStyle.Render("🔍 Fetching Git Repositories"))
-		}
+		printHeader("🔍 Fetching Git Repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
-
-		if dryRun {
-			log.Info("Dry run mode - no actual git operations will be performed")
-		}
-
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			log.Error("Failed to find git repositories: %s", err)
 			return
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 
@@ -77,7 +60,7 @@ var FetchAllCmd = &cobra.Command{
 			eg.Go(func() error {
 				repoName := filepath.Base(rPath)
 
-				if dryRun {
+				if setup.DryRun {
 					spinner := multi.AddSpinner(fmt.Sprintf("[DRY RUN] Would fetch repository at: %s", rPath))
 					spinner.Success()
 					successCount.Add(1)

--- a/cmd/git/git.go
+++ b/cmd/git/git.go
@@ -7,12 +7,56 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
 	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/config"
 	"github.com/eng618/eng/internal/log"
+	"github.com/eng618/eng/internal/ui"
+	"github.com/eng618/eng/internal/ui/theme"
 )
+
+// GitCommandSetup holds common variables and flags resolved during git command initialization.
+type GitCommandSetup struct {
+	IsVerbose bool
+	DryRun    bool
+	DevPath   string
+}
+
+// setupGitCommand abstracts the duplicated setup and validation steps shared across git commands.
+func setupGitCommand(cmd *cobra.Command) (*GitCommandSetup, error) {
+	isVerbose := cmdutil.IsVerbose(cmd)
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	devPath, err := getWorkingPath(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Verbose(isVerbose, "Development path: %s", devPath)
+
+	if dryRun {
+		log.Info("Dry run mode - no actual git operations will be performed")
+	}
+
+	return &GitCommandSetup{
+		IsVerbose: isVerbose,
+		DryRun:    dryRun,
+		DevPath:   devPath,
+	}, nil
+}
+
+// printHeader prints a stylized header consistently to log.Out if progress display is enabled.
+func printHeader(text string) {
+	headerStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(theme.Primary).
+		MarginBottom(1)
+	if !ui.DisableProgress {
+		fmt.Fprintln(log.Out, headerStyle.Render(text))
+	}
+}
 
 // GitCmd serves as the base command for all git repository management operations.
 // It doesn't perform any action itself but groups subcommands like sync-all, status-all, etc.

--- a/cmd/git/list.go
+++ b/cmd/git/list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/ui"
 	"github.com/eng618/eng/internal/ui/theme"
@@ -21,40 +20,31 @@ var ListCmd = &cobra.Command{
 	Short: "List all git repositories in development folder",
 	Long:  `This command lists all git repositories found in your development folder.`,
 	Run: func(cmd *cobra.Command, _args []string) {
-		headerStyle := lipgloss.NewStyle().
-			Bold(true).
-			Foreground(theme.Primary).
-			MarginBottom(1)
-		if !ui.DisableProgress {
-			fmt.Fprintln(log.Out, headerStyle.Render("📁 Development Git Repositories"))
-		}
+		printHeader("📁 Development Git Repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-		showPaths, _ := cmd.Flags().GetBool("paths")
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
+		showPaths, _ := cmd.Flags().GetBool("paths")
 
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			log.Error("Failed to find git repositories: %s", err)
 			return
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 
 		var cardLines []string
 		cardLines = append(cardLines, fmt.Sprintf("Found %s repositories in %s:",
 			theme.PrimaryText.Bold(true).Render(fmt.Sprintf("%d", len(repos))),
-			theme.BoldText.Render(devPath),
+			theme.BoldText.Render(setup.DevPath),
 		))
 		cardLines = append(cardLines, "")
 

--- a/cmd/git/pull_all.go
+++ b/cmd/git/pull_all.go
@@ -6,11 +6,9 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/repo"
 	"github.com/eng618/eng/internal/ui"
@@ -24,37 +22,22 @@ var PullAllCmd = &cobra.Command{
 	Short: "Pull all git repositories in development folder",
 	Long:  `This command pulls with rebase for all git repositories found in your development folder. Use this after fetch-all for faster operations.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		headerStyle := lipgloss.NewStyle().
-			Bold(true).
-			Foreground(theme.Primary).
-			MarginBottom(1)
-		if !ui.DisableProgress {
-			fmt.Fprintln(log.Out, headerStyle.Render("📥 Pulling Git Repositories"))
-		}
+		printHeader("📥 Pulling Git Repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
-
-		if dryRun {
-			log.Info("Dry run mode - no actual git operations will be performed")
-		}
-
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			log.Error("Failed to find git repositories: %s", err)
 			return
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 
@@ -78,7 +61,7 @@ var PullAllCmd = &cobra.Command{
 			eg.Go(func() error {
 				repoName := filepath.Base(rPath)
 
-				if dryRun {
+				if setup.DryRun {
 					spinner := multi.AddSpinner(fmt.Sprintf("[DRY RUN] Would pull repository at: %s", rPath))
 					spinner.Success()
 					successCount.Add(1)

--- a/cmd/git/push_all.go
+++ b/cmd/git/push_all.go
@@ -6,13 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/repo"
-	"github.com/eng618/eng/internal/ui"
 	"github.com/eng618/eng/internal/ui/theme"
 )
 
@@ -23,42 +20,28 @@ var PushAllCmd = &cobra.Command{
 	Short: "Push all git repositories in development folder",
 	Long:  `This command pushes commits for all git repositories found in your development folder that have unpushed commits.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		headerStyle := lipgloss.NewStyle().
-			Bold(true).
-			Foreground(theme.Primary).
-			MarginBottom(1)
-		if !ui.DisableProgress {
-			fmt.Fprintln(log.Out, headerStyle.Render("📤 Pushing Git Repositories"))
-		}
+		printHeader("📤 Pushing Git Repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		force, _ := cmd.Flags().GetBool("force")
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
-
-		if dryRun {
-			log.Info("Dry run mode - no actual git operations will be performed")
-		}
+		force, _ := cmd.Flags().GetBool("force")
 
 		if force {
 			log.Warn("Force push mode enabled - this will force push to remote")
 		}
 
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			log.Error("Failed to find git repositories: %s", err)
 			return
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 
@@ -70,9 +53,9 @@ var PushAllCmd = &cobra.Command{
 
 		for _, repoPath := range repos {
 			repoName := filepath.Base(repoPath)
-			log.Verbose(isVerbose, "Checking repository: %s", repoName)
+			log.Verbose(setup.IsVerbose, "Checking repository: %s", repoName)
 
-			if dryRun {
+			if setup.DryRun {
 				hasUnpushed, err := hasUnpushedCommits(repoPath)
 				if err != nil {
 					log.Error("  [DRY RUN] Failed to check for unpushed commits: %s", err)
@@ -83,7 +66,7 @@ var PushAllCmd = &cobra.Command{
 					log.Info("  [DRY RUN] Would push repository at: %s", repoPath)
 					successCount++
 				} else {
-					log.Verbose(isVerbose, "  [DRY RUN] No unpushed commits, skipping: %s", repoPath)
+					log.Verbose(setup.IsVerbose, "  [DRY RUN] No unpushed commits, skipping: %s", repoPath)
 					skippedCount++
 				}
 				continue
@@ -98,7 +81,7 @@ var PushAllCmd = &cobra.Command{
 			}
 
 			if !hasUnpushed {
-				log.Verbose(isVerbose, "  No unpushed commits, skipping: %s", repoName)
+				log.Verbose(setup.IsVerbose, "  No unpushed commits, skipping: %s", repoName)
 				skippedCount++
 				continue
 			}

--- a/cmd/git/stash_all.go
+++ b/cmd/git/stash_all.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 )
 
@@ -19,30 +18,22 @@ var StashAllCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, _args []string) {
 		log.Start("Stashing changes in all git repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		message, _ := cmd.Flags().GetString("message")
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
+		message, _ := cmd.Flags().GetString("message")
 
-		if dryRun {
-			log.Info("Dry run mode - no actual git operations will be performed")
-		}
-
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			log.Error("Failed to find git repositories: %s", err)
 			return
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 
@@ -56,7 +47,7 @@ var StashAllCmd = &cobra.Command{
 			repoName := filepath.Base(repoPath)
 			log.Info("Checking repository: %s", repoName)
 
-			if dryRun {
+			if setup.DryRun {
 				hasChanges, err := hasUncommittedChanges(repoPath)
 				if err != nil {
 					log.Error("  [DRY RUN] Failed to check for changes: %s", err)

--- a/cmd/git/status_all.go
+++ b/cmd/git/status_all.go
@@ -6,10 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/repo"
 	"github.com/eng618/eng/internal/ui"
@@ -22,30 +20,20 @@ var StatusAllCmd = &cobra.Command{
 	Short: "Check status of all git repositories in development folder",
 	Long:  `This command checks the status of all git repositories found in your development folder.`,
 	Run: func(cmd *cobra.Command, _args []string) {
-		headerStyle := lipgloss.NewStyle().
-			Bold(true).
-			Foreground(theme.Primary).
-			MarginBottom(1)
-		if !ui.DisableProgress {
-			fmt.Println(headerStyle.Render("📊 Development Repositories Status"))
-		}
+		printHeader("📊 Development Repositories Status")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
-
 		var scanSpinner *ui.Spinner
 		if !ui.DisableProgress {
-			scanSpinner = ui.NewSpinner(fmt.Sprintf("Scanning git repositories in %s...", devPath))
+			scanSpinner = ui.NewSpinner(fmt.Sprintf("Scanning git repositories in %s...", setup.DevPath))
 		}
 
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			if scanSpinner != nil {
 				scanSpinner.Stop()
@@ -59,7 +47,7 @@ var StatusAllCmd = &cobra.Command{
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 
@@ -100,7 +88,7 @@ var StatusAllCmd = &cobra.Command{
 		var boxLines []string
 		boxLines = append(boxLines, fmt.Sprintf("Checked %s repository(ies) in %s:",
 			theme.PrimaryText.Bold(true).Render(fmt.Sprintf("%d", len(repos))),
-			theme.BoldText.Render(devPath),
+			theme.BoldText.Render(setup.DevPath),
 		))
 		boxLines = append(boxLines, "")
 		boxLines = append(boxLines, fmt.Sprintf("  %-30s %-20s %s",

--- a/cmd/git/sync_all.go
+++ b/cmd/git/sync_all.go
@@ -6,11 +6,9 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/eng618/eng/internal/cmdutil"
 	"github.com/eng618/eng/internal/log"
 	"github.com/eng618/eng/internal/repo"
 	"github.com/eng618/eng/internal/ui"
@@ -24,37 +22,22 @@ var SyncAllCmd = &cobra.Command{
 	Short: "Sync all git repositories in development folder",
 	Long:  `This command fetches and pulls with rebase for all git repositories found in your development folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		headerStyle := lipgloss.NewStyle().
-			Bold(true).
-			Foreground(theme.Primary).
-			MarginBottom(1)
-		if !ui.DisableProgress {
-			fmt.Fprintln(log.Out, headerStyle.Render("🔄 Syncing Git Repositories"))
-		}
+		printHeader("🔄 Syncing Git Repositories")
 
-		isVerbose := cmdutil.IsVerbose(cmd)
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-
-		devPath, err := getWorkingPath(cmd)
+		setup, err := setupGitCommand(cmd)
 		if err != nil {
 			log.Error("%s", err)
 			return
 		}
 
-		log.Verbose(isVerbose, "Development path: %s", devPath)
-
-		if dryRun {
-			log.Info("Dry run mode - no actual git operations will be performed")
-		}
-
-		repos, err := findGitRepositories(devPath)
+		repos, err := findGitRepositories(setup.DevPath)
 		if err != nil {
 			log.Error("Failed to find git repositories: %s", err)
 			return
 		}
 
 		if len(repos) == 0 {
-			log.Warn("No git repositories found in %s", devPath)
+			log.Warn("No git repositories found in %s", setup.DevPath)
 			return
 		}
 
@@ -78,7 +61,7 @@ var SyncAllCmd = &cobra.Command{
 			eg.Go(func() error {
 				repoName := filepath.Base(rPath)
 
-				if dryRun {
+				if setup.DryRun {
 					spinner := multi.AddSpinner(fmt.Sprintf("[DRY RUN] Would sync repository at: %s", rPath))
 					spinner.Success()
 					successCount.Add(1)


### PR DESCRIPTION
The setup and validation logic in the `cmd/git` subcommands was highly repetitive. We extracted a `setupGitCommand` helper function and a `printHeader` utility to centralize and dry up this logic. All affected Git subcommands are refactored, and all tests pass cleanly.

---
*PR created automatically by Jules for task [11263125126547804842](https://jules.google.com/task/11263125126547804842) started by @eng618*