### PR TITLE
Export repo.IsCloned and replace unexported helpers

### DIFF
--- a/internal/project/fetch.go
+++ b/internal/project/fetch.go
@@ -3,7 +3,6 @@ package project
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -11,6 +10,7 @@ import (
 
 	"github.com/eng618/eng/internal/config"
 	"github.com/eng618/eng/internal/log"
+	"github.com/eng618/eng/internal/repo"
 	"github.com/eng618/eng/internal/ui"
 )
 
@@ -66,8 +66,8 @@ func Fetch(ctx context.Context, opts FetchOptions) {
 	for _, project := range projects {
 		projectPath := filepath.Join(opts.DevPath, project.Name)
 
-		for _, repo := range project.Repos {
-			r := repo // explicitly capture loop variable for closure
+		for _, repoItem := range project.Repos {
+			r := repoItem // explicitly capture loop variable for closure
 
 			eg.Go(func() error {
 				repoPath, err := r.GetEffectivePath()
@@ -82,7 +82,7 @@ func Fetch(ctx context.Context, opts FetchOptions) {
 				fullRepoPath := filepath.Join(projectPath, repoPath)
 
 				// Check if repo exists
-				if !isRepoCloned(fullRepoPath) {
+				if !repo.IsCloned(fullRepoPath) {
 					if opts.IsVerbose {
 						spinner := multi.AddSpinner(fmt.Sprintf("Skipping %s (not cloned)", repoPath))
 						spinner.Warning()
@@ -140,9 +140,4 @@ func Fetch(ctx context.Context, opts FetchOptions) {
 			log.Error("  - %s", r)
 		}
 	}
-}
-
-func isRepoCloned(repoPath string) bool {
-	info, err := os.Stat(filepath.Join(repoPath, ".git"))
-	return err == nil && info.IsDir()
 }

--- a/internal/project/fetch_test.go
+++ b/internal/project/fetch_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/eng618/eng/internal/config"
 	"github.com/eng618/eng/internal/log"
+	"github.com/eng618/eng/internal/repo"
 	"github.com/eng618/eng/internal/ui"
 )
 
@@ -132,13 +133,13 @@ func TestIsRepoCloned(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Test non-existent path
-	assert.False(t, isRepoCloned(filepath.Join(tmpDir, "nonexistent")))
+	assert.False(t, repo.IsCloned(filepath.Join(tmpDir, "nonexistent")))
 
 	// Test directory without .git
 	noGitDir := filepath.Join(tmpDir, "no-git")
 	err = os.MkdirAll(noGitDir, 0o755)
 	require.NoError(t, err)
-	assert.False(t, isRepoCloned(noGitDir))
+	assert.False(t, repo.IsCloned(noGitDir))
 
 	// Test directory with .git file (not directory)
 	gitFileDir := filepath.Join(tmpDir, "git-file")
@@ -146,11 +147,11 @@ func TestIsRepoCloned(t *testing.T) {
 	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(gitFileDir, ".git"), []byte("gitdir: ../other"), 0o644)
 	require.NoError(t, err)
-	assert.False(t, isRepoCloned(gitFileDir)) // .git must be a directory
+	assert.False(t, repo.IsCloned(gitFileDir)) // .git must be a directory
 
 	// Test directory with .git directory
 	gitDirPath := filepath.Join(tmpDir, "has-git")
 	err = os.MkdirAll(filepath.Join(gitDirPath, ".git"), 0o755)
 	require.NoError(t, err)
-	assert.True(t, isRepoCloned(gitDirPath))
+	assert.True(t, repo.IsCloned(gitDirPath))
 }

--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/eng618/eng/internal/config"
 	"github.com/eng618/eng/internal/log"
+	"github.com/eng618/eng/internal/repo"
 )
 
 // ListOptions holds the configuration for listing projects.
@@ -54,15 +55,15 @@ func List(opts ListOptions) {
 			log.Info("  Path: %s", projectPath)
 			log.Info("  Repositories (%d):", len(project.Repos))
 
-			for _, repo := range project.Repos {
-				repoPath, err := repo.GetEffectivePath()
+			for _, repoItem := range project.Repos {
+				repoPath, err := repoItem.GetEffectivePath()
 				if err != nil {
-					log.Error("    ✗ %s (invalid path)", repo.URL)
+					log.Error("    ✗ %s (invalid path)", repoItem.URL)
 					continue
 				}
 
 				fullRepoPath := filepath.Join(projectPath, repoPath)
-				cloned := isRepoCloned(fullRepoPath)
+				cloned := repo.IsCloned(fullRepoPath)
 
 				if cloned {
 					log.Success("    ✓ %s", repoPath)
@@ -70,20 +71,20 @@ func List(opts ListOptions) {
 					log.Warn("    ✗ %s (not cloned)", repoPath)
 				}
 
-				log.Info("      URL: %s", repo.URL)
-				if repo.Path != "" {
-					log.Info("      Custom path: %s", repo.Path)
+				log.Info("      URL: %s", repoItem.URL)
+				if repoItem.Path != "" {
+					log.Info("      Custom path: %s", repoItem.Path)
 				}
 			}
 		} else {
 			clonedCount := 0
-			for _, repo := range project.Repos {
-				repoPath, err := repo.GetEffectivePath()
+			for _, r := range project.Repos {
+				repoPath, err := r.GetEffectivePath()
 				if err != nil {
 					continue
 				}
 				fullRepoPath := filepath.Join(projectPath, repoPath)
-				if isRepoCloned(fullRepoPath) {
+				if repo.IsCloned(fullRepoPath) {
 					clonedCount++
 				}
 			}

--- a/internal/project/pull.go
+++ b/internal/project/pull.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eng618/eng/internal/config"
 	"github.com/eng618/eng/internal/log"
+	"github.com/eng618/eng/internal/repo"
 	"github.com/eng618/eng/internal/ui"
 )
 
@@ -82,7 +83,7 @@ func Pull(ctx context.Context, opts PullOptions) {
 				fullRepoPath := filepath.Join(projectPath, repoPath)
 
 				// Check if repo exists
-				if !isRepoCloned(fullRepoPath) {
+				if !repo.IsCloned(fullRepoPath) {
 					if opts.IsVerbose {
 						spinner := multi.AddSpinner(fmt.Sprintf("Skipping %s (not cloned)", repoPath))
 						spinner.Warning()

--- a/internal/project/sync.go
+++ b/internal/project/sync.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/eng618/eng/internal/config"
 	"github.com/eng618/eng/internal/log"
+	"github.com/eng618/eng/internal/repo"
 	"github.com/eng618/eng/internal/ui"
 )
 
@@ -85,7 +86,7 @@ func Sync(ctx context.Context, opts SyncOptions) {
 				fullRepoPath := filepath.Join(projectPath, repoPath)
 
 				// Check if repo exists
-				if !isRepoCloned(fullRepoPath) {
+				if !repo.IsCloned(fullRepoPath) {
 					if opts.IsVerbose {
 						spinner := multi.AddSpinner(fmt.Sprintf("Skipping %s (not cloned)", repoPath))
 						spinner.Warning()

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -322,3 +322,9 @@ func FetchAllPrune(ctx context.Context, repoPath string) error {
 	}
 	return nil
 }
+
+// IsCloned checks if a git repository is cloned at the given path by checking if the `.git` directory exists.
+func IsCloned(repoPath string) bool {
+	info, err := os.Stat(filepath.Join(repoPath, ".git"))
+	return err == nil && info.IsDir()
+}

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -713,3 +713,50 @@ func TestPullLatestCode_Conflict(t *testing.T) {
 		)
 	}
 }
+
+func TestIsCloned(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-is-cloned-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Test non-existent path
+	if IsCloned(filepath.Join(tmpDir, "nonexistent")) {
+		t.Error("Expected IsCloned to return false for non-existent path")
+	}
+
+	// Test directory without .git
+	noGitDir := filepath.Join(tmpDir, "no-git")
+	err = os.MkdirAll(noGitDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+	if IsCloned(noGitDir) {
+		t.Error("Expected IsCloned to return false for directory without .git")
+	}
+
+	// Test directory with .git file (not directory)
+	gitFileDir := filepath.Join(tmpDir, "git-file")
+	err = os.MkdirAll(gitFileDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+	err = os.WriteFile(filepath.Join(gitFileDir, ".git"), []byte("gitdir: ../other"), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if IsCloned(gitFileDir) {
+		t.Error("Expected IsCloned to return false for directory with .git file (not a directory)")
+	}
+
+	// Test directory with .git directory
+	gitDirPath := filepath.Join(tmpDir, "has-git")
+	err = os.MkdirAll(filepath.Join(gitDirPath, ".git"), 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create .git directory: %v", err)
+	}
+	if !IsCloned(gitDirPath) {
+		t.Error("Expected IsCloned to return true for directory with .git directory")
+	}
+}

--- a/internal/ui/dashboard/update.go
+++ b/internal/ui/dashboard/update.go
@@ -455,7 +455,7 @@ func handleAction(m Model, action string) (tea.Model, tea.Cmd) {
 			repoName = repoDef.URL
 		}
 
-		cloned := isRepoCloned(fullPath)
+		cloned := repo.IsCloned(fullPath)
 		if action == "c" && cloned {
 			m.notificationID++
 			m.notification = fmt.Sprintf("Already cloned: %s", repoName)
@@ -559,7 +559,7 @@ func (m Model) popAndRunNextAction() (Model, tea.Cmd) {
 
 		var err error
 
-		cloned := isRepoCloned(item.FullPath)
+		cloned := repo.IsCloned(item.FullPath)
 		if item.Action == "c" && cloned {
 			log.Warn("Already cloned: %s", prettyName)
 			pw.Close()
@@ -721,9 +721,7 @@ func checkRepoStatus(projectName string, repoDef config.ProjectRepo, devPath str
 
 	fullPath := filepath.Join(devPath, projectName, repoPath)
 
-	// Wait, isRepoCloned is internal to project package, we might need a quick hack or to use os.Stat
-	// Let's just use os.Stat directly to avoid cross-package unexported dependency.
-	isCloned := isRepoCloned(fullPath)
+	isCloned := repo.IsCloned(fullPath)
 
 	status := RepoStatus{
 		IsCloned: isCloned,
@@ -758,12 +756,6 @@ func checkRepoStatus(projectName string, repoDef config.ProjectRepo, devPath str
 	}
 }
 
-func isRepoCloned(repoPath string) bool {
-	gitDir := filepath.Join(repoPath, ".git")
-	info, err := os.Stat(gitDir)
-	return err == nil && info.IsDir()
-}
-
 type editorFinishedMsg struct {
 	err error
 }
@@ -784,7 +776,7 @@ func (m Model) openInEditorCmd() (tea.Cmd, error) {
 		relPath, _ := repoDef.GetEffectivePath()
 		targetPath = filepath.Join(m.devPath, p.Name, relPath)
 
-		if !isRepoCloned(targetPath) {
+		if !repo.IsCloned(targetPath) {
 			return nil, fmt.Errorf("repository not cloned yet")
 		}
 	} else {
@@ -815,7 +807,7 @@ func (m Model) openInCustomEditorCmd() (tea.Cmd, error) {
 		relPath, _ := repoDef.GetEffectivePath()
 		targetPath = filepath.Join(m.devPath, p.Name, relPath)
 
-		if !isRepoCloned(targetPath) {
+		if !repo.IsCloned(targetPath) {
 			return nil, fmt.Errorf("repository not cloned yet")
 		}
 	} else {
@@ -851,7 +843,7 @@ func (m Model) openInTerminalCmd() (tea.Cmd, error) {
 		relPath, _ := repoDef.GetEffectivePath()
 		targetPath = filepath.Join(m.devPath, p.Name, relPath)
 
-		if !isRepoCloned(targetPath) {
+		if !repo.IsCloned(targetPath) {
 			return nil, fmt.Errorf("repository not cloned yet")
 		}
 	} else {


### PR DESCRIPTION
Created a public function `repo.IsCloned` inside `internal/repo` package. Refactored `internal/project/` and `internal/ui/dashboard/` to use `repo.IsCloned`. Deleted the unexported `isRepoCloned` functions. Updated and added corresponding unit tests.

---
*PR created automatically by Jules for task [11617066594284863618](https://jules.google.com/task/11617066594284863618) started by @eng618*