### PR TITLE
fix(codemod): safely merge package.json resolutions

### DIFF
--- a/cmd/codemod/native.go
+++ b/cmd/codemod/native.go
@@ -51,12 +51,22 @@ var NativeCmd = &cobra.Command{
 		if err == nil {
 			var pkg map[string]interface{}
 			if json.Unmarshal(packageJsonBytes, &pkg) == nil {
-				pkg["resolutions"] = map[string]interface{}{
-					"lightningcss": "1.30.1",
+				if res, ok := pkg["resolutions"].(map[string]interface{}); ok {
+					res["lightningcss"] = "1.30.1"
+				} else {
+					pkg["resolutions"] = map[string]interface{}{
+						"lightningcss": "1.30.1",
+					}
 				}
-				pkg["overrides"] = map[string]interface{}{
-					"lightningcss": "1.30.1",
+
+				if overrides, ok := pkg["overrides"].(map[string]interface{}); ok {
+					overrides["lightningcss"] = "1.30.1"
+				} else {
+					pkg["overrides"] = map[string]interface{}{
+						"lightningcss": "1.30.1",
+					}
 				}
+
 				if newBytes, err := json.MarshalIndent(pkg, "", "  "); err == nil {
 					_ = os.WriteFile(packageJsonPath, newBytes, 0o644)
 				}


### PR DESCRIPTION
Safely merges `lightningcss` version into `resolutions` and `overrides` when bootstrapping the native project, preserving existing configuration in `package.json`.

---
*PR created automatically by Jules for task [8756561632207547470](https://jules.google.com/task/8756561632207547470) started by @eng618*