### PR TITLE
fix: handle filenames with spaces in git status output

### DIFF
--- a/cmd/dotfiles/copy_changes.go
+++ b/cmd/dotfiles/copy_changes.go
@@ -1,7 +1,6 @@
 package dotfiles
 
 import (
-	"bufio"
 	"bytes"
 	"io"
 	"os"
@@ -110,7 +109,7 @@ var getTargetRepoPathFunc = config.TargetRepoPath
 // getModifiedFilesFunc is injectable for tests.
 var getModifiedFilesFunc = func(repoPath, worktreePath string) ([]string, error) {
 	var buf bytes.Buffer
-	cmd := exec.Command("git", "--git-dir="+repoPath, "--work-tree="+worktreePath, "status", "--porcelain")
+	cmd := exec.Command("git", "--git-dir="+repoPath, "--work-tree="+worktreePath, "status", "--porcelain", "-z")
 	cmd.Stdout = &buf
 	cmd.Stderr = log.ErrorWriter()
 	err := cmd.Run()
@@ -119,9 +118,12 @@ var getModifiedFilesFunc = func(repoPath, worktreePath string) ([]string, error)
 	}
 
 	var files []string
-	scanner := bufio.NewScanner(&buf)
-	for scanner.Scan() {
-		line := scanner.Text()
+	items := bytes.Split(buf.Bytes(), []byte{0})
+	for _, item := range items {
+		if len(item) == 0 {
+			continue
+		}
+		line := string(item)
 		// Git status format: XY PATH
 		// X = staged status, Y = working tree status, followed by space and path starting at index 3
 		if len(line) > 3 && (strings.HasPrefix(line, " M ") || strings.HasPrefix(line, "M ")) {
@@ -129,7 +131,7 @@ var getModifiedFilesFunc = func(repoPath, worktreePath string) ([]string, error)
 		}
 	}
 
-	return files, scanner.Err()
+	return files, nil
 }
 
 // resetFile runs git checkout -- file.


### PR DESCRIPTION
This PR modifies the parsing of `git status --porcelain` to handle filenames with spaces correctly. Instead of relying on line-based text scanning (which causes Git to quote filenames with spaces or special characters), it adds the `-z` flag to use null-terminated output, and splits the byte stream by null bytes using `bytes.Split`. This properly extracts unmodified paths for dotfile synchronization and fixes the bug described in `TestGetModifiedFilesWithSpaces`.

---
*PR created automatically by Jules for task [14709140590965441377](https://jules.google.com/task/14709140590965441377) started by @eng618*