### PR TITLE
🔒 Fix potential command injection vulnerability in system update

### DIFF
--- a/cmd/system/update.go
+++ b/cmd/system/update.go
@@ -290,8 +290,8 @@ func runCleanup(isVerbose, autoApprove bool, cleanupTimeout int) {
 			continue
 		}
 
-		cmdStr := fmt.Sprintf("sudo %s -y", op)
-		cleanupCmd := execCommand("bash", "-c", cmdStr)
+		args := append(strings.Fields(op), "-y")
+		cleanupCmd := execCommand("sudo", args...)
 		cleanupCmd.Stdout = log.Writer()
 		cleanupCmd.Stderr = log.ErrorWriter()
 

--- a/cmd/system/update_test.go
+++ b/cmd/system/update_test.go
@@ -134,7 +134,7 @@ func TestRunCleanup_AutoApprove(t *testing.T) {
 
 	called := false
 	execCommand = func(name string, args ...string) *exec.Cmd {
-		if name == "bash" && strings.Contains(args[1], "apt-get autoremove") {
+		if name == "sudo" && len(args) > 1 && args[0] == "apt-get" && args[1] == "autoremove" {
 			called = true
 		}
 		return exec.Command("echo", "success")


### PR DESCRIPTION
🎯 **What:** The potential command injection vulnerability in `cmd/system/update.go` where `op` string was passed dynamically to `bash -c`.

⚠️ **Risk:** If the `op` variable could be manipulated by a user, it could lead to arbitrary command execution with elevated (`sudo`) privileges, allowing attackers to run unauthorized commands.

🛡️ **Solution:** Used `strings.Fields` to safely split the operation string into a slice of arguments and appended the `-y` flag, then passed these arguments directly to `sudo` using `execCommand("sudo", args...)`. This avoids using a shell completely and mitigates any shell command injection risks. The tests have also been modified to correctly assert the execution of `sudo apt-get autoremove` instead of checking the shell command string.

---
*PR created automatically by Jules for task [2233964800874265434](https://jules.google.com/task/2233964800874265434) started by @eng618*